### PR TITLE
Remove archaic calls working on Ice%ocean_fluxes_top

### DIFF
--- a/full/atm_land_ice_flux_exchange.F90
+++ b/full/atm_land_ice_flux_exchange.F90
@@ -106,7 +106,7 @@ module atm_land_ice_flux_exchange_mod
   use atmos_ocean_fluxes_mod,  only: atmos_ocean_fluxes_init
   use atmos_ocean_fluxes_calc_mod, only: atmos_ocean_fluxes_calc
   use atmos_ocean_dep_fluxes_calc_mod, only: atmos_ocean_dep_fluxes_calc
-  
+
 #ifdef SCM
   ! option to override various surface boundary conditions for SCM
   use scm_forc_mod,            only: do_specified_flux, scm_surface_flux,             &
@@ -586,15 +586,6 @@ contains
       call coupler_type_spawn(ex_gas_fields_ice, Ice%ocean_fields, (/is,is,ie,ie/), &
                               (/js,js,je,je/), (/1, kd/), suffix = '_ice')
     call coupler_type_set_diags(Ice%ocean_fields, 'ice_flux', Ice%axes, Time)
-
-    ! This call sets up a structure that is private to the ice model, and it
-    ! does not belong here.  This line should be eliminated once an update
-    ! to the FMS coupler_types code is made available that overloads the 
-    ! subroutine coupler_type_copy to use 2d and 3d coupler type sources. -RWH
-    if (.not.coupler_type_initialized(Ice%ocean_fluxes_top)) &
-      call coupler_type_spawn(ex_gas_fields_ice, Ice%ocean_fluxes_top, (/is,is,ie,ie/), &
-                              (/js,js,je,je/), (/1, kd/), suffix = '_ice_top')
-    call coupler_type_set_diags(Ice%ocean_fluxes_top, 'ice_flux', Ice%axes, Time)
 
     !allocate land_ice_atmos_boundary
     call mpp_get_compute_domain( Atm%domain, is, ie, js, je )
@@ -1705,7 +1696,7 @@ contains
        call get_from_xgrid (diag_atm, 'ATM', ex_ref, xmap_sfc)
        used = send_data ( id_rh_ref, diag_atm, Time )
     endif
- 
+
     if(id_rh_ref_cmip > 0 .or. id_hurs > 0 .or. id_rhs > 0) then
        call get_from_xgrid (diag_atm, 'ATM', ex_ref2, xmap_sfc)
        if (id_rh_ref_cmip > 0) used = send_data ( id_rh_ref_cmip, diag_atm, Time )


### PR DESCRIPTION
  Removed archaic calls creating and setting up Ice%ocean_fluxes_top from the
coupler code.  This structure should have always been private to ice models, and
is not even used by any ice models that are still in active development or use,
but until now this wasteful, unused element had to be retained because of these
misplaced calls.  For any older ice models, the fact that the FMS coupler_types
code supports a copy from a 2d coupler type to a 3d coupler type means that this
could be set up inside of the ice model if it is still needed.  In the
MOM6-examples test suite, all answers are bitwise identical with these changes.