### PR TITLE
Updated simple coupler to call data_override_init properly

### DIFF
--- a/simple/coupler_main.F90
+++ b/simple/coupler_main.F90
@@ -473,9 +473,12 @@ contains
     call    ice_model_init (Ice,  Time_init, Time_atmos, Time_step_atmos, Time_step_ocean, &
                             glon_bnd, glat_bnd, atmos_domain=Atm%Domain)
 
-    call data_override_init ( ) ! Atm_domain_in  = Atm%domain, &
-                                ! Ice_domain_in  = Ice%domain, &
-                                ! Land_domain_in = Land%domain )
+    call data_override_init(Atm_domain_in = Atm%domain)
+    call data_override_init(Ice_domain_in = Ice%domain)
+    call data_override_init(Land_domain_in = Land%domain)
+#ifndef _USE_LEGACY_LAND_
+    call data_override_init(Land_domainUG_in = Land%ug_domain)
+#endif
 
 !------------------------------------------------------------------------
 !---- setup allocatable storage for fluxes exchanged between models ----


### PR DESCRIPTION
Note: This has not been tested as it only really affects the doubly_periodic model.

Fixes #33 