### PR TITLE
Implement fms2_io to full coupler

### DIFF
--- a/full/atm_land_ice_flux_exchange.F90
+++ b/full/atm_land_ice_flux_exchange.F90
@@ -30,7 +30,6 @@ module atm_land_ice_flux_exchange_mod
   use   mpp_domains_mod,  only: mpp_get_global_domain, mpp_get_data_domain
   use   mpp_domains_mod,  only: mpp_set_global_domain, mpp_set_data_domain, mpp_set_compute_domain
   use   mpp_domains_mod,  only: mpp_deallocate_domain, mpp_copy_domain, domain2d, mpp_compute_extent
-  use   mpp_io_mod,       only: mpp_close, mpp_open, MPP_MULTI, MPP_SINGLE, MPP_OVERWR
   use   atmos_model_mod,  only: atmos_data_type, land_ice_atmos_boundary_type
   use   ocean_model_mod,  only: ocean_public_type, ice_ocean_boundary_type
   use   ocean_model_mod,  only: ocean_state_type
@@ -72,7 +71,6 @@ module atm_land_ice_flux_exchange_mod
   use      constants_mod, only: rdgas, rvgas, cp_air, stefan, WTMAIR, HLV, HLF, Radius, &
                                 PI, CP_OCEAN, WTMCO2, WTMC, EPSLN, GRAV
   use fms_mod,            only: clock_flag_default, check_nml_error, error_mesg
-  use fms_mod,            only: open_namelist_file, write_version_number
   use data_override_mod,  only: data_override
   use coupler_types_mod,  only: coupler_1d_bc_type, coupler_type_copy, ind_psurf, ind_u10, ind_flux, ind_flux0
   use coupler_types_mod,  only: coupler_type_initialized, coupler_type_spawn

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -326,12 +326,13 @@ program coupler_main
   use time_manager_mod,        only: date_to_string, increment_date
   use time_manager_mod,        only: operator(>=), operator(<=), operator(==)
 
-  use fms_mod,                 only: open_namelist_file, check_nml_error
+  use fms_mod,                 only: check_nml_error
   use fms_mod,                 only: uppercase, error_mesg, write_version_number
   use fms_mod,                 only: fms_init, fms_end, stdout
 
   use fms_io_mod,              only: fms_io_exit !< Can't get rid of this until fms_io is no longer used at all
 
+  use fms2_io_mod,             only: ascii_read
   use fms2_io_mod,             only: FmsNetcdfDomainFile_t
   use fms2_io_mod,             only: write_restart, read_restart, write_data
   use fms2_io_mod,             only: get_global_io_domain_indices
@@ -415,9 +416,6 @@ program coupler_main
   use mpp_mod,                 only: stderr, stdlog, mpp_error, NOTE, FATAL, WARNING
   use mpp_mod,                 only: mpp_set_current_pelist, mpp_declare_pelist
   use mpp_mod,                 only: input_nml_file
-
-  use mpp_io_mod,              only: mpp_open, mpp_close, mpp_io_clock_on
-  use mpp_io_mod,              only: MPP_NATIVE, MPP_RDONLY, MPP_DELETE
 
   use mpp_domains_mod,         only: mpp_broadcast_domain
 
@@ -1182,7 +1180,7 @@ contains
     character(len=256), parameter   :: note_header =                                &
          '==>Note from ' // trim(mod_name) // '(' // trim(sub_name) // '):'
 
-    integer :: unit,  ierr, io,    m, i, outunit, logunit, errunit
+    integer :: ierr, io,    m, i, outunit, logunit, errunit
     integer :: date(6)
     type (time_type) :: Run_length
     character(len=9) :: month
@@ -1203,6 +1201,9 @@ contains
     character(len=10) :: walltime
     character(len=5)  :: wallzone
     integer           :: wallvalues(8)
+    character(len=:), dimension(:), allocatable :: restart_file !< Restart file saved as a string
+    integer :: time_stamp_unit !< Unif of the time_stamp file
+    integer :: ascii_unit  !< Unit of a dummy ascii file
 
     type(coupler_1d_bc_type), pointer :: &
       gas_fields_atm => NULL(), &  ! A pointer to the type describing the
@@ -1228,42 +1229,16 @@ contains
 
 !----- read namelist -------
 
-#ifdef INTERNAL_FILE_NML
     read (input_nml_file, coupler_nml, iostat=io)
     ierr = check_nml_error (io, 'coupler_nml')
-#else
-    unit = open_namelist_file()
-    ierr=1; do while (ierr /= 0)
-      read (unit, nml=coupler_nml, iostat=io, end=10)
-      ierr = check_nml_error (io, 'coupler_nml')
-    enddo
-10  call mpp_close(unit)
-#endif
-
-!---- when concurrent is set true and mpp_io_nml io_clock_on is set true, the model
-!---- will crash with error message "MPP_CLOCK_BEGIN: cannot change pelist context of a clock",
-!---- so need to make sure it will not happen
-    if (concurrent) then
-      if (mpp_io_clock_on()) then
-        call error_mesg ('program coupler', 'when coupler_nml variable concurrent is set to true, '// &
-             'mpp_io_nml variable io_clock_non can not be set to true.', FATAL )
-      endif
-    endif
 
 !----- read date and calendar type from restart file -----
     if (file_exists('INPUT/coupler.res')) then
-!Balaji: currently written in binary, needs form=MPP_NATIVE
-      call mpp_open( unit, 'INPUT/coupler.res', action=MPP_RDONLY )
-      read( unit,*,err=999 )calendar_type
-      read( unit,* )date_init
-      read( unit,* )date
-      goto 998 !back to fortran-4
-!read old-style coupler.res
-999   call mpp_close(unit)
-      call mpp_open( unit, 'INPUT/coupler.res', action=MPP_RDONLY, form=MPP_NATIVE )
-      read(unit)calendar_type
-      read(unit)date
-998   call mpp_close(unit)
+       call ascii_read('INPUT/coupler.res', restart_file)
+       read(restart_file(1), *) calendar_type
+       read(restart_file(2), *) date_init
+       read(restart_file(3), *) date
+       deallocate(restart_file)
     else
       force_date_from_namelist = .true.
     endif
@@ -1602,9 +1577,9 @@ contains
 
 !--- get the time that last intermediate restart file was written out.
     if (file_exists('INPUT/coupler.intermediate.res')) then
-       call mpp_open(unit,'INPUT/coupler.intermediate.res',action=MPP_RDONLY)
-       read(unit,*) date_restart
-       call mpp_close(unit)
+       call ascii_read('INPUT/coupler.intermediate.res', restart_file)
+       read(restart_file(1), *) date_restart
+       deallocate(restart_file)
     else
        date_restart = date
     endif
@@ -1624,17 +1599,17 @@ contains
 !-----------------------------------------------------------------------
 !----- write time stamps (for start time and end time) ------
 
-    call mpp_open( unit, 'time_stamp.out', nohdrs=.TRUE. )
+    if ( mpp_pe().EQ.mpp_root_pe() ) open(newunit = time_stamp_unit, file='time_stamp.out', status='replace', form='formatted')
 
     month = month_name(date(2))
-    if ( mpp_pe().EQ.mpp_root_pe() ) write (unit,20) date, month(1:3)
+    if ( mpp_pe().EQ.mpp_root_pe() ) write (time_stamp_unit,20) date, month(1:3)
 
     call get_date (Time_end, date(1), date(2), date(3),  &
                    date(4), date(5), date(6))
     month = month_name(date(2))
-    if ( mpp_pe().EQ.mpp_root_pe() ) write (unit,20) date, month(1:3)
+    if ( mpp_pe().EQ.mpp_root_pe() ) write (time_stamp_unit,20) date, month(1:3)
 
-    call mpp_close(unit)
+    if ( mpp_pe().EQ.mpp_root_pe() ) close(time_stamp_unit)
 
 20  format (i6,5i4,2x,a3)
 
@@ -1912,8 +1887,10 @@ contains
 !-----------------------------------------------------------------------
 !---- open and close dummy file in restart dir to check if dir exists --
 
-    call mpp_open( unit, 'RESTART/file' )
-    call mpp_close(unit, MPP_DELETE)
+    if ( mpp_pe().EQ.mpp_root_pe() ) then
+       open(newunit = ascii_unit, file='RESTART/file', status='replace', form='formatted')
+       close(ascii_unit,status="delete")
+    endif
 
     ! Call to daig_grid_end to free up memory used during regional
     ! output setup
@@ -2033,7 +2010,8 @@ contains
     type(time_type),   intent(in)           :: Time_run, Time_res
     character(len=*), intent(in),  optional :: time_stamp
     character(len=128)                      :: file_run, file_res
-    integer :: yr, mon, day, hr, min, sec, date(6), unit, n
+    integer :: yr, mon, day, hr, min, sec, date(6), n
+    integer :: restart_unit !< Unit for the coupler restart file
 
     call mpp_set_current_pelist()
 
@@ -2049,26 +2027,26 @@ contains
     !----- compute current date ------
     call get_date (Time_run, date(1), date(2), date(3),  &
                    date(4), date(5), date(6))
-    call mpp_open( unit, file_run, nohdrs=.TRUE. )
     if ( mpp_pe().EQ.mpp_root_pe()) then
-       write( unit, '(i6,8x,a)' )calendar_type, &
+       open(newunit = restart_unit, file=file_run, status='replace', form='formatted')
+       write(restart_unit, '(i6,8x,a)' )calendar_type, &
             '(Calendar: no_calendar=0, thirty_day_months=1, julian=2, gregorian=3, noleap=4)'
 
-       write( unit, '(6i6,8x,a)' )date_init, &
+       write(restart_unit, '(6i6,8x,a)' )date_init, &
             'Model start time:   year, month, day, hour, minute, second'
-       write( unit, '(6i6,8x,a)' )date, &
+       write(restart_unit, '(6i6,8x,a)' )date, &
             'Current model time: year, month, day, hour, minute, second'
+       close(restart_unit)
     endif
-    call mpp_close(unit)
 
     if (Time_res > Time_start) then
-      call mpp_open( unit, file_res, nohdrs=.TRUE. )
       if ( mpp_pe().EQ.mpp_root_pe()) then
+        open(newunit = restart_unit, file=file_res, status='replace', form='formatted')
         call get_date(Time_res ,yr,mon,day,hr,min,sec)
-        write( unit, '(6i6,8x,a)' )yr,mon,day,hr,min,sec, &
+        write(restart_unit, '(6i6,8x,a)' )yr,mon,day,hr,min,sec, &
              'Current intermediate restart time: year, month, day, hour, minute, second'
+        close(restart_unit)
       endif
-      call mpp_close(unit)
     endif
 
     if (Ocean%is_ocean_pe) then

--- a/full/flux_exchange.F90
+++ b/full/flux_exchange.F90
@@ -507,7 +507,7 @@ module flux_exchange_mod
   use mpp_domains_mod, only: mpp_deallocate_domain, mpp_copy_domain, domain2d, mpp_compute_extent
   use mpp_domains_mod, only: mpp_get_layout, mpp_define_layout
 
-  use mpp_io_mod,      only: mpp_close, mpp_open, MPP_MULTI, MPP_SINGLE, MPP_OVERWR
+  use mpp_io_mod,      only: mpp_open, MPP_SINGLE, MPP_OVERWR
 
 !model_boundary_data_type contains all model fields at the boundary.
 !model1_model2_boundary_type contains fields that model2 gets
@@ -535,7 +535,7 @@ module flux_exchange_mod
   use fms2_io_mod,                only: get_variable_size, get_variable_dimension_names, variable_exists
   use fms2_io_mod,                only: read_data, register_field, register_axis
   use fms_mod,                    only: clock_flag_default, check_nml_error, error_mesg
-  use fms_mod,                    only: open_namelist_file, write_version_number
+  use fms_mod,                    only:  write_version_number
   use data_override_mod,          only: data_override
   use coupler_types_mod,          only: coupler_1d_bc_type
   use atmos_ocean_fluxes_mod,     only: atmos_ocean_fluxes_init, atmos_ocean_type_fluxes_init
@@ -751,17 +751,8 @@ contains
     logunit = stdlog()
     !----- read namelist -------
 
-#ifdef INTERNAL_FILE_NML
     read (input_nml_file, flux_exchange_nml, iostat=io)
     ierr = check_nml_error (io, 'flux_exchange_nml')
-#else
-    unit = open_namelist_file()
-    ierr=1; do while (ierr /= 0)
-    read  (unit, nml=flux_exchange_nml, iostat=io, end=10)
-    ierr = check_nml_error (io, 'flux_exchange_nml')
-    enddo
-10  call mpp_close(unit)
-#endif
 
     !----- write namelist to logfile -----
     call write_version_number (version, tag)

--- a/full/flux_exchange.F90
+++ b/full/flux_exchange.F90
@@ -499,7 +499,7 @@ module flux_exchange_mod
        mpp_clock_id, mpp_clock_begin, mpp_clock_end, mpp_sum, mpp_max, &
        CLOCK_COMPONENT, CLOCK_SUBCOMPONENT, CLOCK_ROUTINE, lowercase, &
        input_nml_file, mpp_get_current_pelist
-  use mpp_domains_mod, only: mpp_create_super_grid, mpp_define_io_domain
+  use mpp_domains_mod, only: mpp_create_super_grid_domain, mpp_define_io_domain
   use mpp_domains_mod, only: mpp_get_compute_domain, mpp_get_compute_domains, &
                              mpp_global_sum, mpp_redistribute, operator(.EQ.)
   use mpp_domains_mod, only: mpp_get_global_domain, mpp_get_data_domain
@@ -996,7 +996,7 @@ contains
        call close_file(atm_mosaic_file_obj)
 
        call mpp_copy_domain(Atm%domain, domain2)
-       call mpp_create_super_grid(domain2)
+       call mpp_create_super_grid_domain(domain2)
        call mpp_define_io_domain  (domain2, (/1,1/))
 
        call mpp_get_compute_domain(domain2, isc2, iec2, jsc2, jec2)

--- a/full/flux_exchange.F90
+++ b/full/flux_exchange.F90
@@ -986,8 +986,12 @@ contains
        call read_data(atm_mosaic_file_obj, "gridfiles", buffer, corner=1)
 
        !< Remove the .tile from the filename to get basename
-       ppos = scan(trim(buffer),".tile")
-       if ( ppos > 0 ) tile_file = buffer(1:ppos+1)//".nc"
+       ppos = index(trim(buffer),".tile")
+       if ( ppos > 0 ) then
+          tile_file = buffer(1:ppos+1)//".nc"
+       else
+          tile_file = buffer
+       endif
 
        call close_file(atm_mosaic_file_obj)
 

--- a/full/flux_exchange.F90
+++ b/full/flux_exchange.F90
@@ -507,8 +507,6 @@ module flux_exchange_mod
   use mpp_domains_mod, only: mpp_deallocate_domain, mpp_copy_domain, domain2d, mpp_compute_extent
   use mpp_domains_mod, only: mpp_get_layout, mpp_define_layout
 
-  use mpp_io_mod,      only: mpp_open, MPP_SINGLE, MPP_OVERWR
-
 !model_boundary_data_type contains all model fields at the boundary.
 !model1_model2_boundary_type contains fields that model2 gets
 !from model1, may also include fluxes. These are declared by
@@ -872,10 +870,9 @@ contains
     integer :: i
 
     stocks_file=stdout()
-    ! Divert output file for stocks if requested 
+    ! If the divert_stocks_report is set to true, write the stocks to a new file "stocks.out"
     if(mpp_pe()==mpp_root_pe() .and. divert_stocks_report) then
-       call mpp_open( stocks_file, 'stocks.out', action=MPP_OVERWR, threading=MPP_SINGLE, &
-            fileset=MPP_SINGLE, nohdrs=.TRUE. )       
+       open(newunit = stocks_file, file='stocks.out', status='replace', form='formatted')
     endif
 
     ! Initialize stock values


### PR DESCRIPTION
Requires:
1. FMS2_io ascii io: git@github.com:GFDL-Eric/FMS.git ascii_io
2. FMS2_io's version of coupler_types: git@github.com:uramirez8707/FMS.git fms2_io_coupler_types
3. Supergrid creation: git@github.com:uramirez8707/FMS.git supergrid

This PR:

1.  The coupler restart files are now read with fms2_io's [ascii_read](https://github.com/GFDL-Eric/FMS/blob/d61bfa851e476cf5e5aecb647d2c06f0e7ebdd97/fms2_io/fms_io_utils.F90#L461-L468)
2. Ascii writes are now done with fortran's `open`, `close`, and `write`. They are wrapped in an if, so that only the root pe does the io, `newunit` ensures that the unit number is unique for each file. I renamed the variables `unit` because that's already a fortran thing ...
3. The coupler type restarts are now written with fms2_io. 
4. The grid file is now read with fms2_io in: full/flux_exchange.F90:check_atm_grid
