### PR TITLE
Fixes a get_variable_size call in flux/flux_exchange

### DIFF
--- a/full/flux_exchange.F90
+++ b/full/flux_exchange.F90
@@ -913,7 +913,7 @@ contains
     joff = lbound(Atm%lon_bnd,2) - jsc
 
     if(variable_exists(grid_file_obj, "AREA_ATM" ) ) then  ! old grid
-       call get_variable_size(grid_file_obj, "AREA_ATM", siz)
+       call get_variable_size(grid_file_obj, "AREA_ATM", siz(1:2))
        nlon = siz(1)
        nlat = siz(2)
 


### PR DESCRIPTION
Fixes #59 

Corrects a `get_variable_size` call to prevent ` FATAL: incorrect size of dim_sizes array.` crashes when running with the SCM. 