### PR TITLE
Add allocations for u_ref and v_ref

### DIFF
--- a/simple/flux_exchange.F90
+++ b/simple/flux_exchange.F90
@@ -766,6 +766,8 @@ subroutine flux_up_to_atmos (Time, Land, Ice, Boundary )
 !------ allocate land-ice-atmos boundary
 
    allocate( land_ice_atmos_boundary%t(is:ie,js:je) )
+   allocate( land_ice_atmos_boundary%u_ref(is:ie,js:je) )
+   allocate( land_ice_atmos_boundary%v_ref(is:ie,js:je) )
    allocate( land_ice_atmos_boundary%t_ref(is:ie,js:je) )
    allocate( land_ice_atmos_boundary%q_ref(is:ie,js:je) )
    allocate( land_ice_atmos_boundary%albedo(is:ie,js:je) )


### PR DESCRIPTION
Fixes failures while running in debug mode with gnu.

Tested with aquaplanet regressions, fixed gnu issues.