### PR TITLE
Data override updates and bugfixes

### DIFF
--- a/SHiELD/coupler_main.F90
+++ b/SHiELD/coupler_main.F90
@@ -386,7 +386,7 @@ contains
     call print_memuse_stats('after atmos model init')
 
 !------ initialize data_override -----
-    call data_override_init (Atm_domain_in  = Atm%domain)
+    if (.NOT.Atm%bounded_domain) call data_override_init (Atm_domain_in  = Atm%domain)
 
 !-----------------------------------------------------------------------
 !---- open and close dummy file in restart dir to check if dir exists --

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -1368,10 +1368,11 @@ contains
       !--- setting affinity
       if (do_concurrent_radiation) then
 !$      call fms_affinity_set('ATMOS', use_hyper_thread, atmos_nthreads + radiation_nthreads)
+!$      call omp_set_num_threads(atmos_nthreads+radiation_nthreads)
       else
 !$      call fms_affinity_set('ATMOS', use_hyper_thread, atmos_nthreads)
+!$      call omp_set_num_threads(atmos_nthreads)
       endif
-!$    call omp_set_num_threads(atmos_nthreads)
     endif
 
    !--- initialization clock
@@ -1732,8 +1733,10 @@ contains
       if (concurrent) then
         call mpp_set_current_pelist( Ocean%pelist )
 !$      call fms_affinity_set('OCEAN', use_hyper_thread, ocean_nthreads)
+!$      call omp_set_num_threads(ocean_nthreads)
       else
         ocean_nthreads = atmos_nthreads
+        !--- omp_num_threads has already been set by the Atmos-pes, but set again to ensure
 !$      call omp_set_num_threads(ocean_nthreads)
       endif
 

--- a/simple/coupler_main.F90
+++ b/simple/coupler_main.F90
@@ -443,7 +443,7 @@ contains
                             glon_bnd, glat_bnd, atmos_domain=Atm%Domain)
 
 !------ initialize data_override -----
-    call data_override_init(Atm_domain_in = Atm%domain)
+    if (.NOT.Atm%bounded_domain) call data_override_init(Atm_domain_in = Atm%domain)
     call data_override_init(Ice_domain_in = Ice%domain)
     call data_override_init(Land_domain_in = Land%domain)
 

--- a/simple/coupler_main.F90
+++ b/simple/coupler_main.F90
@@ -243,7 +243,6 @@ contains
     integer :: total_days, total_seconds, ierr, io
     integer :: n, gnlon, gnlat
     integer :: date(6), flags
-    integer :: dt_size
     type (time_type) :: Run_length
     character(len=9) :: month
     logical :: use_namelist
@@ -443,18 +442,10 @@ contains
     call    ice_model_init (Ice,  Time_init, Time_atmos, Time_step_atmos, Time_step_ocean, &
                             glon_bnd, glat_bnd, atmos_domain=Atm%Domain)
 
-    if (file_exists('data_table')) then
-      inquire(file='data_table', size=dt_size)
-      if (dt_size > 0.) then
-        call data_override_init(Atm_domain_in = Atm%domain)
-        call data_override_init(Ice_domain_in = Ice%domain)
-        call data_override_init(Land_domain_in = Land%domain)
-      else
-        call error_mesg ('program coupler', 'empty data table, skipping data override init', WARNING)
-      endif
-    else
-      call error_mesg ('program coupler', 'no data table, skipping data override init', WARNING)
-    endif
+!------ initialize data_override -----
+    call data_override_init(Atm_domain_in = Atm%domain)
+    call data_override_init(Ice_domain_in = Ice%domain)
+    call data_override_init(Land_domain_in = Land%domain)
 
 !------------------------------------------------------------------------
 !---- setup allocatable storage for fluxes exchanged between models ----
@@ -464,9 +455,6 @@ contains
                       !!!!!  atmos_land_boundary,        &
                              atmos_ice_boundary,         &
                              land_ice_atmos_boundary     )
-
-
-
 
 !-----------------------------------------------------------------------
 !---- open and close dummy file in restart dir to check if dir exists --

--- a/simple/coupler_main.F90
+++ b/simple/coupler_main.F90
@@ -443,7 +443,7 @@ contains
                             glon_bnd, glat_bnd, atmos_domain=Atm%Domain)
 
 !------ initialize data_override -----
-    if (.NOT.Atm%bounded_domain) call data_override_init(Atm_domain_in = Atm%domain)
+    call data_override_init(Atm_domain_in = Atm%domain)
     call data_override_init(Ice_domain_in = Ice%domain)
     call data_override_init(Land_domain_in = Land%domain)
 


### PR DESCRIPTION
Removes grid code and variables from SHiELD/coupler_main and fixes data_override_init
Removes outdated logic in simple/coupler_main for data_override_init parsing

Relies upon [FMS PR #933](https://github.com/NOAA-GFDL/FMS/pull/933)