### PR TITLE
Replacing omp_set_nested 

### DIFF
--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -1359,7 +1359,7 @@ contains
     !--- dynamic threading turned off when affinity placement is in use
 !$  call omp_set_dynamic(.FALSE.)
     !--- nested OpenMP enabled for OpenMP concurrent components
-!$  call omp_set_max_active_levels(huge(0)) 
+!$  call omp_set_max_active_levels(3)
 
     if (Atm%pe) then
       call mpp_set_current_pelist( Atm%pelist )

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -1359,7 +1359,7 @@ contains
     !--- dynamic threading turned off when affinity placement is in use
 !$  call omp_set_dynamic(.FALSE.)
     !--- nested OpenMP enabled for OpenMP concurrent components
-!$  call omp_set_nested(.TRUE.)
+!$  call omp_set_max_active_levels(huge(0)) 
 
     if (Atm%pe) then
       call mpp_set_current_pelist( Atm%pelist )


### PR DESCRIPTION
This sets a large value for omp_set_max_active_levels which should default to the implementation maximum.  This resolves #68 