### PR TITLE
Update constant initialization routine name

### DIFF
--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -314,7 +314,7 @@ program coupler_main
   use omp_lib
 
   use FMS, status_fms=>status
-  use FMSconstants, only: constants_init
+  use FMSconstants, only: fmsconstants_init
 
   !< Can't get rid of this until fms_io is no longer used at all
   use fms_io_mod,              only: fms_io_exit
@@ -562,7 +562,7 @@ program coupler_main
   call mpp_clock_begin(initClock)
 
   call fms_init
-  call constants_init
+  call fmsconstants_init
   call fms_affinity_init
 
   call coupler_init

--- a/simple/coupler_main.F90
+++ b/simple/coupler_main.F90
@@ -60,7 +60,7 @@ use flux_exchange_mod,  only: flux_exchange_init,   &
                               !flux_exchange_end       ! may not be used?
 !--- FMS modules
 use FMS
-use FMSconstants, only: constants_init
+use FMSconstants, only: fmsconstants_init
 
 !--- FMS old io
 use fms_io_mod, only: fms_io_exit!< This can't be removed until fms_io is not used at all
@@ -137,7 +137,7 @@ implicit none
    call mpp_clock_begin (initClock)
 
    call fms_init
-   call constants_init
+   call fmsconstants_init
    call fms_affinity_init
 
    call coupler_init


### PR DESCRIPTION
Updates the constants init routines to use the updated name from https://github.com/NOAA-GFDL/FMS/pull/929

needs this to compile with current FMS main