### PR TITLE
webhook trigger for fms updates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,8 @@
+---
+title: Compile test failed with FMS update 
+assignees: rem1776
+labels: maintenance
+---
+The CI failed compiliation of the null model with the latest FMS main branch.
+
+[Link to failing FMS commit](https://github.com/rem1776/FMS/commit/{{ env.REF }})

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         run: t/null_model_build.sh
         id: test
       - name: Create issue if FMS update fails compilation
-        if: ${{ steps.test.outcome == 'failure' }} && ${{ github.event == 'workflow_dispatch' }}
+        if: ${{ steps.test.outcome == 'failure' && github.event == 'workflow_dispatch' }}
         uses: JasonEtco/create-an-issue@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         run: t/null_model_build.sh
         id: test
       - name: Create issue if FMS update fails compilation
-        if: ${{ failure() }} && ${{ github.event == 'workflow_dispatch' }}
+        if: ${{ steps.test.outcome == 'failure' }} && ${{ github.event == 'workflow_dispatch' }}
         uses: JasonEtco/create-an-issue@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         run: t/null_model_build.sh
         id: test
       - name: Create issue if FMS update fails compilation
-        if: ${{ steps.test.outcome == 'failure' }} && ${{ github.event == 'workflow_dispatch' }}
+        if: ${{ failure() }} && ${{ github.event == 'workflow_dispatch' }}
         uses: JasonEtco/create-an-issue@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -28,4 +28,3 @@ jobs:
         with:
           update_existing: true
           search_existing: open
-          continue-on-error: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,13 @@
 name: FMScoupler build test
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     container:
       image: underwoo/ubuntu_libfms_gnu
-      env: 
+      env:
         CC: mpicc
         FC: mpif90
         CPPFLAGS: '-I/usr/include -Duse_LARGEFILE -DMAXFIELDMETHODS_=500'
@@ -16,5 +16,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Run build test 
+      - name: Run build test
         run: t/null_model_build.sh
+        id: test
+      - name: Create issue if FMS update fails compilation
+        if: failure() && ${{ github.event == 'workflow_dispatch' }}
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF: ${{ steps.test.outputs.sha }}
+        with:
+          update_existing: true
+          search_existing: open

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         run: t/null_model_build.sh
         id: test
       - name: Create issue if FMS update fails compilation
-        if: failure() && ${{ github.event == 'workflow_dispatch' }}
+        if: ${{ steps.test.outcome == 'failure' }} && ${{ github.event == 'workflow_dispatch' }}
         uses: JasonEtco/create-an-issue@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -28,3 +28,4 @@ jobs:
         with:
           update_existing: true
           search_existing: open
+          continue-on-error: true

--- a/t/null_model_build.sh
+++ b/t/null_model_build.sh
@@ -2,6 +2,7 @@
 #
 # Script to build a GFDL null model, using all null components, and run
 # a simple test on CI systems, like Travis CI or gitlab CI.
+
 # Determine the where this script lives, and set some variables that contain
 # other useful directories.
 script_root=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
@@ -27,8 +28,6 @@ git clone https://github.com/NOAA-GFDL/FMS.git $src_dir/FMS
 cd $src_dir/FMS
 echo "::set-output name=sha::`git log -1 --pretty=format:%H`"
 cd $bld_dir
-
-exit 1 # test issue creation on failure
 
 # ocean_null
 git clone https://github.com/NOAA-GFDL/ocean_null.git $src_dir/ocean_null

--- a/t/null_model_build.sh
+++ b/t/null_model_build.sh
@@ -25,10 +25,12 @@ mk_template=${bld_dir}/mkmf/templates/linux-ubuntu-xenial-gnu.mk
 
 # FMS
 git clone https://github.com/NOAA-GFDL/FMS.git $src_dir/FMS
+cd $src_dir/FMS
+echo "::set-output name=sha::`git log -1 --pretty=format:%H`"
+cd $bld_dir
 
 # ocean_null
 git clone https://github.com/NOAA-GFDL/ocean_null.git $src_dir/ocean_null
-cd $bld_dir
 
 # atmos_null
 git clone https://github.com/NOAA-GFDL/atmos_null.git $src_dir/atmos_null

--- a/t/null_model_build.sh
+++ b/t/null_model_build.sh
@@ -2,7 +2,6 @@
 #
 # Script to build a GFDL null model, using all null components, and run
 # a simple test on CI systems, like Travis CI or gitlab CI.
-exit 1 # test issue creation on failure
 # Determine the where this script lives, and set some variables that contain
 # other useful directories.
 script_root=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
@@ -28,6 +27,8 @@ git clone https://github.com/NOAA-GFDL/FMS.git $src_dir/FMS
 cd $src_dir/FMS
 echo "::set-output name=sha::`git log -1 --pretty=format:%H`"
 cd $bld_dir
+
+exit 1 # test issue creation on failure
 
 # ocean_null
 git clone https://github.com/NOAA-GFDL/ocean_null.git $src_dir/ocean_null

--- a/t/null_model_build.sh
+++ b/t/null_model_build.sh
@@ -2,7 +2,7 @@
 #
 # Script to build a GFDL null model, using all null components, and run
 # a simple test on CI systems, like Travis CI or gitlab CI.
-
+exit 1 # test issue creation on failure
 # Determine the where this script lives, and set some variables that contain
 # other useful directories.
 script_root=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)


### PR DESCRIPTION
Adds the 'workflow_dispatch' trigger so the CI can be triggered by FMS.

Also adds a step to create a new issue if the coupler CI fails with a FMS main update. The issue will follow the added template and will not create a duplicate as long as the last one is open.

tested on my fork [here](https://github.com/rem1776/FMScoupler/issues/3)