### PR TITLE
Fixes to run the null model

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: underwoo/ubuntu_libfms_gnu
+      image: ryanmulhall/hpc-me.ubuntu-minimal:coupler
       env: 
         CC: mpicc
         FC: mpif90

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: ryanmulhall/hpc-me.ubuntu-minimal:coupler
+      image: noaagfdl/hpc-me.ubuntu-minimal:coupler
       env: 
         CC: mpicc
         FC: mpif90

--- a/simple/ice_model.F90
+++ b/simple/ice_model.F90
@@ -593,9 +593,7 @@ real :: lon0, lond, latd, amp, t_control, dellon, dom_wid, siggy, tempi
 
 need_ic = .false.
 
-
-
-if ( open_file(ice_restart_fileobj, 'INPUT/ice_model.res.nc', 'read', Ice%domain, is_restart=.true.)) then
+if (open_file(ice_restart_fileobj, 'INPUT/ice_model.res.nc', 'read', Ice%domain, is_restart=.true.)) then
    if (mpp_pe() == mpp_root_pe()) call error_mesg ('ice_model_mod', &
             'Reading NetCDF formatted restart file: INPUT/ice_model.res.nc', NOTE)
 

--- a/simple/ice_model.F90
+++ b/simple/ice_model.F90
@@ -422,8 +422,6 @@ real :: lon0, lond, latd, amp, t_control, dellon, dom_wid, siggy, tempi
  logical :: need_ic
  type(FmsNetcdfDomainFile_t) :: land_mask_fileobj !< Land mask domain decomposed fileobj
  type(FmsNetcdfDomainFile_t) :: ice_restart_fileobj !< Ice restart domain decomposed fileobj
- logical :: do_io = .true. !< Determines if input files (ice_mask.nc, ice restart) should be read in
-                            !! Based on if io domain is allocated
 
  if (module_is_initialized) then
      return
@@ -526,12 +524,13 @@ real :: lon0, lond, latd, amp, t_control, dellon, dom_wid, siggy, tempi
   !enddo
   !enddo
 
-  ! check if io domain set up, if so check if file can be opened
-  do_io = associated( mpp_get_io_domain(Ice%domain) )
-  if( do_io ) do_io = open_file(land_mask_fileobj, 'INPUT/land_mask.nc', 'read', Ice%domain)
+  ! set io domain if not there in order to check files
+  if ( .not. associated(mpp_get_io_domain(Ice%domain)) ) then
+    call mpp_define_io_domain(Ice%domain, (/ 1, 1 /) )
+  endif
 
   ! read the land mask from a file (land=1)
-  if (do_io) then
+  if (open_file(land_mask_fileobj, 'INPUT/land_mask.nc', 'read', Ice%domain)) then
       call read_data (land_mask_fileobj, 'land_mask', Ice%glon)
       where (Ice%glon > 0.50)
          Ice%gmask = .false.
@@ -594,9 +593,9 @@ real :: lon0, lond, latd, amp, t_control, dellon, dom_wid, siggy, tempi
 
 need_ic = .false.
 
-if( do_io ) do_io = open_file(ice_restart_fileobj, 'INPUT/ice_model.res.nc', 'read', Ice%domain, is_restart=.true.)
 
-if ( do_io ) then
+
+if ( open_file(ice_restart_fileobj, 'INPUT/ice_model.res.nc', 'read', Ice%domain, is_restart=.true.)) then
    if (mpp_pe() == mpp_root_pe()) call error_mesg ('ice_model_mod', &
             'Reading NetCDF formatted restart file: INPUT/ice_model.res.nc', NOTE)
 
@@ -1163,7 +1162,6 @@ print *, 'pe,count(ice,all,ocean)=',mpp_pe(),count(Ice%ice_mask),count(Ice%mask)
  integer :: unit
  character(len=64) :: fname='RESTART/ice_model.res.nc'
  type(FmsNetcdfDomainFile_t) :: ice_restart_fileobj !< Ice restart domain decomposed fileobj
- logical :: do_io = .true. !< set if io files should be read
 
  if (.not.module_is_initialized) return
  if( do_netcdf_restart) then
@@ -1172,10 +1170,7 @@ print *, 'pe,count(ice,all,ocean)=',mpp_pe(),count(Ice%ice_mask),count(Ice%mask)
        call error_mesg ('ice_model_mod', 'Writing NetCDF formatted restart file: RESTART/ice_model.res.nc', NOTE)
     endif
 
-    ! check if io domain set up, if so check if file can be opened
-    do_io = associated( mpp_get_io_domain(Ice%domain) )
-    if( do_io ) do_io = open_file(ice_restart_fileobj, fname, 'overwrite', Ice%domain, is_restart=.true.)
-    if (do_io) then
+    if (open_file(ice_restart_fileobj, fname, 'overwrite', Ice%domain, is_restart=.true.)) then
         call ice_register_restart(ice_restart_fileobj, Ice)
         call register_field(ice_restart_fileobj, "mlon", "double")
         call register_field(ice_restart_fileobj, "mlat", "double")

--- a/t/null_model_build.sh
+++ b/t/null_model_build.sh
@@ -25,8 +25,8 @@ mk_template=${bld_dir}/mkmf/templates/linux-ubuntu-xenial-gnu.mk
 
 # FMS
 if [ "$1" = "--link-fms" ]; then
-  test -f "${script_root}/../../FMS" || echo "Error: --link-fms specified but FMS src not found(${script_root}/../../FMS)"
-  ln -s $(readlink -f ../../FMS) $src_dir/FMS
+  test -d "${script_root}/../../FMS" || echo "Error: --link-fms specified but FMS src not found(${script_root}/../../FMS)"
+  ln -s $(readlink -f ../FMS) $src_dir/FMS
 else
   git clone https://github.com/NOAA-GFDL/FMS.git $src_dir/FMS
 fi

--- a/t/null_model_build.sh
+++ b/t/null_model_build.sh
@@ -25,7 +25,8 @@ mk_template=${bld_dir}/mkmf/templates/linux-ubuntu-xenial-gnu.mk
 
 # FMS
 if [ "$1" = "--link-fms" ]; then
-  test -d "${script_root}/../../FMS" || echo "Error: --link-fms specified but FMS src not found(${script_root}/../../FMS)"
+  #test -d "${script_root}/../../FMS" || echo "Error: --link-fms specified but FMS src not found(${script_root}/../../FMS)"
+  ls && ls ~ && ls ..
   ln -s $(readlink -f ../FMS) $src_dir/FMS
 else
   git clone https://github.com/NOAA-GFDL/FMS.git $src_dir/FMS

--- a/t/null_model_build.sh
+++ b/t/null_model_build.sh
@@ -164,13 +164,11 @@ make -j NETCDF=3 DEBUG=on coupler_simple_test.x
 # Report on the status of the build
 if [ $? -eq 0 ]
 then
-  echo "<NOTE> : make succeeded - simple coupler."
+  echo "::note title=Build Succeeded:: null model built successfully."
 else
-  echo "<NOTE> : make failed - simple coupler."
+  echo "::error title=Build Failed:: null model failed compilation."
   exit 1
 fi
-### 17FEB2021 exit 0 to prevent model running.  This is temporary
-exit 0
 # Run the null models test
 # Setup the run directory
 mkdir ${bld_dir}/run
@@ -184,15 +182,14 @@ tar zxf ${tarFile}
 # Get the full namelist
 ln -s input-full.nml input.nml
 # Run the null model with the full coupler
-### 17FEB2021 commented out the run because it crashes
-#mpiexec -n 1 ${bld_dir}/coupler_full_test.x
+mpiexec -n 1 ${bld_dir}/coupler_full_test.x
 
 # Report on the status of the run with the full coupler
 if [ $? -eq 0 ]
 then
-  echo "<NOTE> : run succeeded - full coupler."
+  echo "::note title=Run Succeeded - full coupler:: Full coupler null model ran successfully."
 else
-  echo "<NOTE> : run failed - full coupler."
+  echo "::error title=Run Failed - full coupler:: Full coupler null model run failed execution."
   exit 1
 fi
 
@@ -204,6 +201,13 @@ mkdir RESTART
 rm input.nml
 ln -s input-simple.nml input.nml
 # Run the null simple coupler test
-### 17FEB2021 commented out the run because it crashes
-#mpiexec -n 1 ${bld_dir}/coupler_simple_test.x
+mpiexec -n 1 ${bld_dir}/coupler_simple_test.x
 
+# Report on the status of the run with the simple coupler
+if [ $? -eq 0 ]
+then
+  echo "::note title=Run Succeeded - simple coupler:: simple coupler null model ran successfully"
+else
+  echo "::error title=Run Failed - simple coupler:: simple coupler null model run failed execution."
+  exit 1
+fi

--- a/t/null_model_build.sh
+++ b/t/null_model_build.sh
@@ -24,11 +24,11 @@ export PATH=${PATH}:${bld_dir}/mkmf/bin
 mk_template=${bld_dir}/mkmf/templates/linux-ubuntu-xenial-gnu.mk
 
 # FMS
-git clone https://github.com/NOAA-GFDL/FMS.git $src_dir/FMS
-if [ "$1" ]; then
-  cd $src_dir/FMS
-  git checkout "$1" || echo "::error title=Run Failed:: Could not checkout commit $1"
-  cd $bld_dir
+if [ "$1" == "--link-fms" ]; then
+  test -f "${script_root}/../../FMS" || echo "Error: --link-fms specified but FMS src not found(${script_root}/../../FMS)"
+  ln -s $(readlink -f ../../FMS) $src_dir/FMS
+else
+  git clone https://github.com/NOAA-GFDL/FMS.git $src_dir/FMS
 fi
 
 # ocean_null

--- a/t/null_model_build.sh
+++ b/t/null_model_build.sh
@@ -94,7 +94,7 @@ EOF
 mkdir -p $bld_dir/fms
 list_paths -o $bld_dir/fms/pathnames_fms $src_dir/FMS
 cd $bld_dir/fms
-mkmf -m Makefile -a $src_dir -b $bld_dir -p libfms.a -t $mkmf_template -g -c "-Duse_netCDF -Duse_libMPI -DMAXFIELDS_=200 -DMAXFIELDMETHODS_=200 -DINTERNAL_FILE_NML" -IFMS/include -IFMS/mpp/include $bld_dir/fms/pathnames_fms
+mkmf -m Makefile -a $src_dir -b $bld_dir -p libfms.a -t $mkmf_template -g -c "-Duse_netCDF -Duse_libMPI -DMAXFIELDS_=200 -DMAXFIELDMETHODS_=200 -DINTERNAL_FILE_NML -DHAVE_GETTID" -IFMS/include -IFMS/mpp/include $bld_dir/fms/pathnames_fms
 cd $bld_dir
 
 # libocean_null

--- a/t/null_model_build.sh
+++ b/t/null_model_build.sh
@@ -99,7 +99,7 @@ EOF
 mkdir -p $bld_dir/fms
 list_paths -o $bld_dir/fms/pathnames_fms $src_dir/FMS
 cd $bld_dir/fms
-mkmf -m Makefile -a $src_dir -b $bld_dir -p libfms.a -t $mkmf_template -g -c "-Duse_netCDF -Duse_libMPI -DMAXFIELDS_=200 -DMAXFIELDMETHODS_=200 -DINTERNAL_FILE_NML" -IFMS/include -IFMS/mpp/include $bld_dir/fms/pathnames_fms
+mkmf -m Makefile -a $src_dir -b $bld_dir -p libfms.a -t $mkmf_template -g -c "-Duse_netCDF -Duse_libMPI -DMAXFIELDS_=200 -DMAXFIELDMETHODS_=200 -DINTERNAL_FILE_NML -DHAVE_GETTID" -IFMS/include -IFMS/mpp/include $bld_dir/fms/pathnames_fms
 cd $bld_dir
 
 # libocean_null

--- a/t/null_model_build.sh
+++ b/t/null_model_build.sh
@@ -25,6 +25,11 @@ mk_template=${bld_dir}/mkmf/templates/linux-ubuntu-xenial-gnu.mk
 
 # FMS
 git clone https://github.com/NOAA-GFDL/FMS.git $src_dir/FMS
+if [ "$1" ]; then
+  cd $src_dir/FMS
+  git checkout "$1" || echo "::error title=Run Failed:: Could not checkout commit $1"
+  cd $bld_dir
+fi
 
 # ocean_null
 git clone https://github.com/NOAA-GFDL/ocean_null.git $src_dir/ocean_null

--- a/t/null_model_build.sh
+++ b/t/null_model_build.sh
@@ -26,8 +26,10 @@ mk_template=${bld_dir}/mkmf/templates/linux-ubuntu-xenial-gnu.mk
 # FMS
 if [ "$1" = "--link-fms" ]; then
   #test -d "${script_root}/../../FMS" || echo "Error: --link-fms specified but FMS src not found(${script_root}/../../FMS)"
-  ls && ls ~ && ls ..
-  ln -s $(readlink -f ../FMS) $src_dir/FMS
+  ls ../../../
+  echo asdsdsad
+  ls ../..
+  ln -s $(readlink -f ../../../FMS) $src_dir/FMS
 else
   git clone https://github.com/NOAA-GFDL/FMS.git $src_dir/FMS
 fi

--- a/t/null_model_build.sh
+++ b/t/null_model_build.sh
@@ -24,12 +24,9 @@ export PATH=${PATH}:${bld_dir}/mkmf/bin
 mk_template=${bld_dir}/mkmf/templates/linux-ubuntu-xenial-gnu.mk
 
 # FMS
-if [ "$1" = "--link-fms" ]; then
-  #test -d "${script_root}/../../FMS" || echo "Error: --link-fms specified but FMS src not found(${script_root}/../../FMS)"
-  ls ../../../
-  echo asdsdsad
-  ls ../..
-  ln -s $(readlink -f ../../../FMS) $src_dir/FMS
+if [ "$1" = "--local-fms" ]; then
+  test -d "../../../FMS" || echo "Error: --local-fms specified but FMS src not found in parent directory" 1>&2
+  cp -r ../../../FMS $src_dir/FMS
 else
   git clone https://github.com/NOAA-GFDL/FMS.git $src_dir/FMS
 fi
@@ -102,7 +99,7 @@ EOF
 mkdir -p $bld_dir/fms
 list_paths -o $bld_dir/fms/pathnames_fms $src_dir/FMS
 cd $bld_dir/fms
-mkmf -m Makefile -a $src_dir -b $bld_dir -p libfms.a -t $mkmf_template -g -c "-Duse_netCDF -Duse_libMPI -DMAXFIELDS_=200 -DMAXFIELDMETHODS_=200 -DINTERNAL_FILE_NML -DHAVE_GETTID" -IFMS/include -IFMS/mpp/include $bld_dir/fms/pathnames_fms
+mkmf -m Makefile -a $src_dir -b $bld_dir -p libfms.a -t $mkmf_template -g -c "-Duse_netCDF -Duse_libMPI -DMAXFIELDS_=200 -DMAXFIELDMETHODS_=200 -DINTERNAL_FILE_NML" -IFMS/include -IFMS/mpp/include $bld_dir/fms/pathnames_fms
 cd $bld_dir
 
 # libocean_null

--- a/t/null_model_build.sh
+++ b/t/null_model_build.sh
@@ -152,9 +152,9 @@ make -j NETCDF=3 DEBUG=on coupler_full_test.x
 # Report on the status of the build
 if [ $? -eq 0 ]
 then
-  echo "<NOTE> : make succeeded - full coupler."
+  echo "::note title=Build Succeeded:: null model with full coupler built successfully."
 else
-  echo "<NOTE> : make failed - full coupler."
+  echo "::error title=Build Failed:: null model with full coupler failed compilation."
   exit 1
 fi
 
@@ -164,9 +164,9 @@ make -j NETCDF=3 DEBUG=on coupler_simple_test.x
 # Report on the status of the build
 if [ $? -eq 0 ]
 then
-  echo "::note title=Build Succeeded:: null model built successfully."
+  echo "::note title=Build Succeeded:: null model with simple coupler built successfully."
 else
-  echo "::error title=Build Failed:: null model failed compilation."
+  echo "::error title=Build Failed:: null model with simple coupler failed compilation."
   exit 1
 fi
 # Run the null models test

--- a/t/null_model_build.sh
+++ b/t/null_model_build.sh
@@ -24,7 +24,7 @@ export PATH=${PATH}:${bld_dir}/mkmf/bin
 mk_template=${bld_dir}/mkmf/templates/linux-ubuntu-xenial-gnu.mk
 
 # FMS
-if [ "$1" == "--link-fms" ]; then
+if [ "$1" = "--link-fms" ]; then
   test -f "${script_root}/../../FMS" || echo "Error: --link-fms specified but FMS src not found(${script_root}/../../FMS)"
   ln -s $(readlink -f ../../FMS) $src_dir/FMS
 else


### PR DESCRIPTION
Changes the script to add an option to copy FMS instead of cloning in order to run in the CI for https://github.com/NOAA-GFDL/FMS/pull/975 , and changes the output so it'll  be displayed on github.

Also makes a few code changes to allow the null model tests to run. 
The ice model would fail from attempting to read without an io domain, so the added code just checks for an associated io domain before it tries to open the ice files. 