### PR TITLE
Add ifdefs for fms_io_exit calls

### DIFF
--- a/SHiELD/coupler_main.F90
+++ b/SHiELD/coupler_main.F90
@@ -32,8 +32,9 @@ use atmos_model_mod, only: atmos_model_init, atmos_model_end,  &
                            update_atmos_model_state,           &
                            atmos_data_type, atmos_model_restart
 !--- FMS old io
+#ifdef use_deprecated_io
 use fms_io_mod, only: fms_io_exit!< This can't be removed until fms_io is not used at all
-
+#endif
 implicit none
 
 !-----------------------------------------------------------------------
@@ -454,7 +455,9 @@ contains
    call diag_manager_end (Time_atmos)
 
 !----- to be removed once fms_io is fully deprecated -----
+#ifdef use_deprecated_io
    call fms_io_exit()
+#endif
 
 !-----------------------------------------------------------------------
 

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -337,8 +337,9 @@ program coupler_main
   use FMS, status_fms=>status
   use FMSconstants, only: fmsconstants_init
 
-  !< Can't get rid of this until fms_io is no longer used at all
+#ifdef use_deprecated_io
   use fms_io_mod,              only: fms_io_exit
+#endif
 
 ! model interfaces used to couple the component models:
 !               atmosphere, land, ice, and ocean
@@ -1960,7 +1961,9 @@ contains
     call coupler_restart(Time, Time_restart_current)
 
     call diag_manager_end (Time)
+#ifdef use_deprecated_io
     call fms_io_exit
+#endif
     call mpp_set_current_pelist()
 
 !-----------------------------------------------------------------------

--- a/simple/coupler_main.F90
+++ b/simple/coupler_main.F90
@@ -64,7 +64,9 @@ use FMS
 use FMSconstants, only: fmsconstants_init
 
 !--- FMS old io
+#ifdef use_deprecated_io
 use fms_io_mod, only: fms_io_exit!< This can't be removed until fms_io is not used at all
+#endif
 
 implicit none
 
@@ -513,8 +515,9 @@ contains
     call   ice_model_end (Ice)
 
     call diag_manager_end (Time_atmos)
-
+#ifdef use_deprecated_io
     call  fms_io_exit
+#endif
 
 ! call flux_exchange_end (Atm)
 


### PR DESCRIPTION
adds ifdefs for io deprecation

tested this with the null model, just pulled https://github.com/NOAA-GFDL/FMS/pull/1064 instead of main for FMS