### PR TITLE
Changes to allow data atmosphere with the interspersed sea-ice coupling

### DIFF
--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -1757,7 +1757,7 @@ contains
         call mpp_set_current_pelist(Ice%fast_pelist)
       elseif (Ice%slow_ice_pe) then
         call mpp_set_current_pelist(Ice%slow_pelist)
-      elseif ((.not.Ice%slow_ice_pe).and.(.not.Ice%fast_ice_pe)) then
+      else
         call mpp_error(FATAL, "All Ice%pes must be a part of Ice%fast_ice_pe or Ice%slow_ice_pe")
       endif
       if (mpp_pe().EQ.mpp_root_pe()) then


### PR DESCRIPTION
In the current form, the coupler does not correctly assign PEs when using a data atmosphere (do_atmos=false) and the combined ice-ocean driver (combined_ice_and_ocean = .true.). In that case, all PEs are atmosphere PEs, ocean PEs, slow-ice PEs, and fast-ice PEs. To address this, new options have been added where the ice PE list is assigned.

The logic where the ice PE list is defined has been changed to use the do_atmos, shared_slow_fast_PEs, and slow_ice_with_ocean options for four cases:
 (1) fully coupled configurations that do not use the combined ice-ocean driver,
 (2) fully coupled configurations that do use the combined ice-ocean driver, 
 (3) data atmosphere configurations that do not use the combined ice-ocean driver, and 
 (4) data atmosphere configurations that do use the combined ice-ocean driver. 
Previously, only the shared_slow_fast_PEs option was needed to define the sea ice PE list. 

To confirm this change is successful, the root PE now writes both the slow and fast ice PE list when using the concurrent_ice option. (Added lines 1479-1505).

Finally, changes were made where the logic assumes that a PE is either a slow and fast ice PE but could not be both. 

Fixes #84 

