### PR TITLE
Changes any FMS routine calls or references to new FMS naming convention

### DIFF
--- a/full/atm_land_ice_flux_exchange.F90
+++ b/full/atm_land_ice_flux_exchange.F90
@@ -241,10 +241,10 @@ use FMSconstants, only: rdgas, rvgas, cp_air, stefan, WTMAIR, HLV, HLF, Radius, 
   integer :: isphum = NO_TRACER       !< index of specific humidity tracer in tracer table
   integer :: ico2   = NO_TRACER       !< index of co2 tracer in tracer table
   integer :: inh3   = NO_TRACER       !< index of nh3 tracer in tracer table
-  type(coupler_1d_bc_type), pointer :: ex_gas_fields_atm=>NULL() !< gas fields in atm
+  type(fms_coupler_1d_bc_type), pointer :: ex_gas_fields_atm=>NULL() !< gas fields in atm
                                                                  !< Place holder for various atmospheric fields.
-  type(coupler_1d_bc_type), pointer :: ex_gas_fields_ice=>NULL() ! gas fields on ice
-  type(coupler_1d_bc_type), pointer :: ex_gas_fluxes=>NULL()     ! gas flux
+  type(fms_coupler_1d_bc_type), pointer :: ex_gas_fields_ice=>NULL() ! gas fields on ice
+  type(fms_coupler_1d_bc_type), pointer :: ex_gas_fluxes=>NULL()     ! gas flux
                                                                  !< Place holder of intermediate calculations, such as
                                                                  !< piston velocities etc.
 
@@ -305,7 +305,7 @@ contains
     logical,              intent(in)    :: do_forecast_in, partition_fprec_from_lprec_in
     integer,              intent(in)    :: nblocks_in
     integer,              intent(in)    :: cplClock_in
-    type(coupler_1d_bc_type), intent(in), target :: ex_gas_fields_atm_in, ex_gas_fields_ice_in, ex_gas_fluxes_in
+    type(fms_coupler_1d_bc_type), intent(in), target :: ex_gas_fields_atm_in, ex_gas_fields_ice_in, ex_gas_fluxes_in
 
     character(len=48), parameter :: module_name = 'flux_exchange_mod'
     character(len=64), parameter    :: sub_name = 'flux_exchange_init'

--- a/full/atmos_ocean_dep_fluxes_calc.F90
+++ b/full/atmos_ocean_dep_fluxes_calc.F90
@@ -34,13 +34,13 @@ contains
   !! \throw FATAL, "atmos_ocean_dep_fluxes_calc: Bad parameter ([gas_fluxes%bc(n)%param(1)]) for air_sea_deposition for [gas_fluxes%bc(n)%name]"
   !! \throw FATAL, "atmos_ocean_dep_fluxes_calc: Unknown implementation ([gas_fluxes%bc(n)%implementation] for [gas_fluxes%bc(n)%name]"
   subroutine atmos_ocean_dep_fluxes_calc(gas_fields_atm, gas_fields_ice, gas_fluxes, seawater)
-    type(fms_coupler_1d_bc_type), intent(in)    :: gas_fields_atm !< Structure containing atmospheric surface
+    type(FmsCoupler1dBC_type), intent(in)    :: gas_fields_atm !< Structure containing atmospheric surface
                                                               !! variables that are used in the calculation
                                                               !! of the atmosphere-ocean gas fluxes.
-    type(fms_coupler_1d_bc_type), intent(in)    :: gas_fields_ice !< Structure containing ice-top and ocean
+    type(FmsCoupler1dBC_type), intent(in)    :: gas_fields_ice !< Structure containing ice-top and ocean
                                                               !! surface variables that are used in the
                                                               !! calculation of the atmosphere-ocean gas fluxes.
-    type(fms_coupler_1d_bc_type), intent(inout) :: gas_fluxes !< Structure containing the gas fluxes between
+    type(FmsCoupler1dBC_type), intent(inout) :: gas_fluxes !< Structure containing the gas fluxes between
                                                           !! the atmosphere and the ocean and parameters
                                                           !! related to the calculation of these fluxes.
     real, dimension(:),       intent(in)    :: seawater   !< 1 for the open water category, 0 if ice or land.
@@ -64,7 +64,7 @@ contains
 
     if (.not. associated(gas_fluxes%bc)) then
       if (gas_fluxes%num_bcs .ne. 0) then
-        call mpp_error(FATAL, trim(error_header) // ' Number of gas fluxes not zero')
+        call fms_mpp_error(FATAL, trim(error_header) // ' Number of gas fluxes not zero')
       else
         return
       endif
@@ -72,11 +72,11 @@ contains
 
     do n = 1, gas_fluxes%num_bcs
       ! only do calculations if the flux has not been overridden
-      if ( .not. gas_fluxes%bc(n)%field(ind_flux)%override) then
+      if ( .not. gas_fluxes%bc(n)%field(fms_coupler_ind_flux)%override) then
         if (gas_fluxes%bc(n)%flux_type .eq. 'air_sea_deposition') then
           if (gas_fluxes%bc(n)%param(1) .le. 0.0) then
             write (error_string, '(1pe10.3)') gas_fluxes%bc(n)%param(1)
-            call mpp_error(FATAL, 'atmos_ocean_dep_fluxes_calc: Bad parameter (' //&
+            call fms_mpp_error(FATAL, 'atmos_ocean_dep_fluxes_calc: Bad parameter (' //&
                 & trim(error_string) // ') for air_sea_deposition for ' //&
                 & trim(gas_fluxes%bc(n)%name))
           endif
@@ -86,23 +86,23 @@ contains
           if (gas_fluxes%bc(n)%implementation .eq. 'dry') then
             do i = 1, length
               if (seawater(i) == 1.) then
-                gas_fluxes%bc(n)%field(ind_flux)%values(i) = &
-                    gas_fields_atm%bc(n)%field(ind_deposition)%values(i) / gas_fluxes%bc(n)%param(1)
+                gas_fluxes%bc(n)%field(fms_coupler_ind_flux)%values(i) = &
+                    gas_fields_atm%bc(n)%field(fms_coupler_ind_deposition)%values(i) / gas_fluxes%bc(n)%param(1)
               else
-                gas_fluxes%bc(n)%field(ind_flux)%values(i) = 0.0
+                gas_fluxes%bc(n)%field(fms_coupler_ind_flux)%values(i) = 0.0
               endif
             enddo
           elseif (gas_fluxes%bc(n)%implementation .eq. 'wet') then
             do i = 1, length
               if (seawater(i) == 1.) then
-                gas_fluxes%bc(n)%field(ind_flux)%values(i) = &
-                    gas_fields_atm%bc(n)%field(ind_deposition)%values(i) / gas_fluxes%bc(n)%param(1)
+                gas_fluxes%bc(n)%field(fms_coupler_ind_flux)%values(i) = &
+                    gas_fields_atm%bc(n)%field(fms_coupler_ind_deposition)%values(i) / gas_fluxes%bc(n)%param(1)
               else
-                gas_fluxes%bc(n)%field(ind_flux)%values(i) = 0.0
+                gas_fluxes%bc(n)%field(fms_coupler_ind_flux)%values(i) = 0.0
               endif
             enddo
           else
-            call mpp_error(FATAL, 'atmos_ocean_dep_fluxes_calc: Unknown implementation ('&
+            call fms_mpp_error(FATAL, 'atmos_ocean_dep_fluxes_calc: Unknown implementation ('&
                 & // trim(gas_fluxes%bc(n)%implementation) // ') for ' // trim(gas_fluxes%bc(n)%name))
           endif
         else

--- a/full/atmos_ocean_dep_fluxes_calc.F90
+++ b/full/atmos_ocean_dep_fluxes_calc.F90
@@ -34,13 +34,13 @@ contains
   !! \throw FATAL, "atmos_ocean_dep_fluxes_calc: Bad parameter ([gas_fluxes%bc(n)%param(1)]) for air_sea_deposition for [gas_fluxes%bc(n)%name]"
   !! \throw FATAL, "atmos_ocean_dep_fluxes_calc: Unknown implementation ([gas_fluxes%bc(n)%implementation] for [gas_fluxes%bc(n)%name]"
   subroutine atmos_ocean_dep_fluxes_calc(gas_fields_atm, gas_fields_ice, gas_fluxes, seawater)
-    type(coupler_1d_bc_type), intent(in)    :: gas_fields_atm !< Structure containing atmospheric surface
+    type(fms_coupler_1d_bc_type), intent(in)    :: gas_fields_atm !< Structure containing atmospheric surface
                                                               !! variables that are used in the calculation
                                                               !! of the atmosphere-ocean gas fluxes.
-    type(coupler_1d_bc_type), intent(in)    :: gas_fields_ice !< Structure containing ice-top and ocean
+    type(fms_coupler_1d_bc_type), intent(in)    :: gas_fields_ice !< Structure containing ice-top and ocean
                                                               !! surface variables that are used in the
                                                               !! calculation of the atmosphere-ocean gas fluxes.
-    type(coupler_1d_bc_type), intent(inout) :: gas_fluxes !< Structure containing the gas fluxes between
+    type(fms_coupler_1d_bc_type), intent(inout) :: gas_fluxes !< Structure containing the gas fluxes between
                                                           !! the atmosphere and the ocean and parameters
                                                           !! related to the calculation of these fluxes.
     real, dimension(:),       intent(in)    :: seawater   !< 1 for the open water category, 0 if ice or land.

--- a/full/atmos_ocean_fluxes_calc.F90
+++ b/full/atmos_ocean_fluxes_calc.F90
@@ -43,13 +43,13 @@ contains
   !! \throw FATAL, "Unknown flux type ([flux_type]) for [name]"
   subroutine atmos_ocean_fluxes_calc(gas_fields_atm, gas_fields_ice,&
       & gas_fluxes, seawater, tsurf, ustar, cd_m)
-    type(fms_coupler_1d_bc_type), intent(in)    :: gas_fields_atm !< Structure containing atmospheric surface
+    type(FmsCoupler1dBC_type), intent(in)    :: gas_fields_atm !< Structure containing atmospheric surface
                                                               !! variables that are used in the calculation
                                                               !! of the atmosphere-ocean gas fluxes.
-    type(fms_coupler_1d_bc_type), intent(in)    :: gas_fields_ice !< Structure containing ice-top and ocean
+    type(FmsCoupler1dBC_type), intent(in)    :: gas_fields_ice !< Structure containing ice-top and ocean
                                                               !! surface variables that are used in the
                                                               !! calculation of the atmosphere-ocean gas fluxes.
-    type(fms_coupler_1d_bc_type), intent(inout) :: gas_fluxes !< Structure containing the gas fluxes between
+    type(FmsCoupler1dBC_type), intent(inout) :: gas_fluxes !< Structure containing the gas fluxes between
                                                           !! the atmosphere and the ocean and parameters
                                                           !! related to the calculation of these fluxes.
     real, dimension(:), intent(in)           :: seawater  !< 1 for the open water category, 0 if ice or land.
@@ -74,7 +74,7 @@ contains
 
     if (.not. associated(gas_fluxes%bc)) then
       if (gas_fluxes%num_bcs .ne. 0) then
-        call mpp_error(FATAL, trim(error_header) // ' Number of gas fluxes not zero')
+        call fms_mpp_error(FATAL, trim(error_header) // ' Number of gas fluxes not zero')
       else
         return
       endif
@@ -82,7 +82,7 @@ contains
 
     do n = 1, gas_fluxes%num_bcs
       ! only do calculations if the flux has not been overridden
-      if ( .not. gas_fluxes%bc(n)%field(ind_flux)%override) then
+      if ( .not. gas_fluxes%bc(n)%field(fms_coupler_ind_flux)%override) then
         if (gas_fluxes%bc(n)%flux_type .eq. 'air_sea_gas_flux_generic') then
           length = size(gas_fluxes%bc(n)%field(1)%values(:))
 
@@ -90,65 +90,65 @@ contains
             allocate( kw(length) )
             allocate ( cair(length) )
           elseif (size(kw(:)) .ne. length) then
-            call mpp_error(FATAL, trim(error_header) // ' Lengths of flux fields do not match')
+            call fms_mpp_error(FATAL, trim(error_header) // ' Lengths of flux fields do not match')
           endif
 
           if (gas_fluxes%bc(n)%implementation .eq. 'ocmip2') then
             do i = 1, length
               if (seawater(i) == 1.) then
-                gas_fluxes%bc(n)%field(ind_kw)%values(i) =&
-                    & gas_fluxes%bc(n)%param(1) * gas_fields_atm%bc(n)%field(ind_u10)%values(i)**2
+                gas_fluxes%bc(n)%field(fms_coupler_ind_kw)%values(i) =&
+                    & gas_fluxes%bc(n)%param(1) * gas_fields_atm%bc(n)%field(fms_coupler_ind_u10)%values(i)**2
                 cair(i) = &
-                    gas_fields_ice%bc(n)%field(ind_alpha)%values(i) * &
-                    gas_fields_atm%bc(n)%field(ind_pCair)%values(i) * &
-                    gas_fields_atm%bc(n)%field(ind_psurf)%values(i) * gas_fluxes%bc(n)%param(2)
-                gas_fluxes%bc(n)%field(ind_flux)%values(i) =&
-                    & gas_fluxes%bc(n)%field(ind_kw)%values(i) *&
-                    & sqrt(660. / (gas_fields_ice%bc(n)%field(ind_sc_no)%values(i) + epsln)) *&
-                    & (gas_fields_ice%bc(n)%field(ind_csurf)%values(i) - cair(i))
-                gas_fluxes%bc(n)%field(ind_flux0)%values(i) =&
-                    & gas_fluxes%bc(n)%field(ind_kw)%values(i) *&
-                    & sqrt(660. / (gas_fields_ice%bc(n)%field(ind_sc_no)%values(i) + epsln)) *&
-                    & gas_fields_ice%bc(n)%field(ind_csurf)%values(i)
-                gas_fluxes%bc(n)%field(ind_deltap)%values(i) =&
-                    & (gas_fields_ice%bc(n)%field(ind_csurf)%values(i) - cair(i)) / &
-                   (gas_fields_ice%bc(n)%field(ind_alpha)%values(i) * permeg + epsln)
+                    gas_fields_ice%bc(n)%field(fms_coupler_ind_alpha)%values(i) * &
+                    gas_fields_atm%bc(n)%field(fms_coupler_ind_pCair)%values(i) * &
+                    gas_fields_atm%bc(n)%field(fms_coupler_ind_psurf)%values(i) * gas_fluxes%bc(n)%param(2)
+                gas_fluxes%bc(n)%field(fms_coupler_ind_flux)%values(i) =&
+                    & gas_fluxes%bc(n)%field(fms_coupler_ind_kw)%values(i) *&
+                    & sqrt(660. / (gas_fields_ice%bc(n)%field(fms_coupler_ind_sc_no)%values(i) + epsln)) *&
+                    & (gas_fields_ice%bc(n)%field(fms_coupler_ind_csurf)%values(i) - cair(i))
+                gas_fluxes%bc(n)%field(fms_coupler_ind_flux0)%values(i) =&
+                    & gas_fluxes%bc(n)%field(fms_coupler_ind_kw)%values(i) *&
+                    & sqrt(660. / (gas_fields_ice%bc(n)%field(fms_coupler_ind_sc_no)%values(i) + epsln)) *&
+                    & gas_fields_ice%bc(n)%field(fms_coupler_ind_csurf)%values(i)
+                gas_fluxes%bc(n)%field(fms_coupler_ind_deltap)%values(i) =&
+                    & (gas_fields_ice%bc(n)%field(fms_coupler_ind_csurf)%values(i) - cair(i)) / &
+                   (gas_fields_ice%bc(n)%field(fms_coupler_ind_alpha)%values(i) * permeg + epsln)
               else
-                gas_fluxes%bc(n)%field(ind_kw)%values(i) = 0.0
-                gas_fluxes%bc(n)%field(ind_flux)%values(i) = 0.0
-                gas_fluxes%bc(n)%field(ind_flux0)%values(i) = 0.0
-                gas_fluxes%bc(n)%field(ind_deltap)%values(i) = 0.0
+                gas_fluxes%bc(n)%field(fms_coupler_ind_kw)%values(i) = 0.0
+                gas_fluxes%bc(n)%field(fms_coupler_ind_flux)%values(i) = 0.0
+                gas_fluxes%bc(n)%field(fms_coupler_ind_flux0)%values(i) = 0.0
+                gas_fluxes%bc(n)%field(fms_coupler_ind_deltap)%values(i) = 0.0
                 cair(i) = 0.0
               endif
             enddo
           elseif (gas_fluxes%bc(n)%implementation .eq. 'duce') then
             do i = 1, length
               if (seawater(i) == 1.) then
-                gas_fluxes%bc(n)%field(ind_kw)%values(i) = &
-                    & gas_fields_atm%bc(n)%field(ind_u10)%values(i) /&
+                gas_fluxes%bc(n)%field(fms_coupler_ind_kw)%values(i) = &
+                    & gas_fields_atm%bc(n)%field(fms_coupler_ind_u10)%values(i) /&
                     & (770.+45.*gas_fluxes%bc(n)%param(1)**(1./3.)) *&
                     & 101325./(rdgas*wtmair*1e-3*tsurf(i) *&
-                    & max(gas_fields_ice%bc(n)%field(ind_alpha)%values(i),epsln))
+                    & max(gas_fields_ice%bc(n)%field(fms_coupler_ind_alpha)%values(i),epsln))
                 !alpha: mol/m3/atm
                 cair(i) = &
-                    gas_fields_ice%bc(n)%field(ind_alpha)%values(i) * &
-                    gas_fields_atm%bc(n)%field(ind_pCair)%values(i) * &
-                    gas_fields_atm%bc(n)%field(ind_psurf)%values(i) * 9.86923e-6
+                    gas_fields_ice%bc(n)%field(fms_coupler_ind_alpha)%values(i) * &
+                    gas_fields_atm%bc(n)%field(fms_coupler_ind_pCair)%values(i) * &
+                    gas_fields_atm%bc(n)%field(fms_coupler_ind_psurf)%values(i) * 9.86923e-6
                 cair(i) = max(cair(i),0.)
-                gas_fluxes%bc(n)%field(ind_flux)%values(i) =&
-                    & gas_fluxes%bc(n)%field(ind_kw)%values(i) *&
-                    & (max(gas_fields_ice%bc(n)%field(ind_csurf)%values(i),0.) - cair(i))
-                gas_fluxes%bc(n)%field(ind_flux0)%values(i) =&
-                    & gas_fluxes%bc(n)%field(ind_kw)%values(i) *&
-                    & max(gas_fields_ice%bc(n)%field(ind_csurf)%values(i),0.)
-                gas_fluxes%bc(n)%field(ind_deltap)%values(i) =&
-                    & (max(gas_fields_ice%bc(n)%field(ind_csurf)%values(i),0.) - cair(i)) /&
-                    & (gas_fields_ice%bc(n)%field(ind_alpha)%values(i) * permeg + epsln)
+                gas_fluxes%bc(n)%field(fms_coupler_ind_flux)%values(i) =&
+                    & gas_fluxes%bc(n)%field(fms_coupler_ind_kw)%values(i) *&
+                    & (max(gas_fields_ice%bc(n)%field(fms_coupler_ind_csurf)%values(i),0.) - cair(i))
+                gas_fluxes%bc(n)%field(fms_coupler_ind_flux0)%values(i) =&
+                    & gas_fluxes%bc(n)%field(fms_coupler_ind_kw)%values(i) *&
+                    & max(gas_fields_ice%bc(n)%field(fms_coupler_ind_csurf)%values(i),0.)
+                gas_fluxes%bc(n)%field(fms_coupler_ind_deltap)%values(i) =&
+                    & (max(gas_fields_ice%bc(n)%field(fms_coupler_ind_csurf)%values(i),0.) - cair(i)) /&
+                    & (gas_fields_ice%bc(n)%field(fms_coupler_ind_alpha)%values(i) * permeg + epsln)
               else
-                gas_fluxes%bc(n)%field(ind_kw)%values(i) = 0.0
-                gas_fluxes%bc(n)%field(ind_flux)%values(i) = 0.0
-                gas_fluxes%bc(n)%field(ind_flux0)%values(i) = 0.0
-                gas_fluxes%bc(n)%field(ind_deltap)%values(i) = 0.0
+                gas_fluxes%bc(n)%field(fms_coupler_ind_kw)%values(i) = 0.0
+                gas_fluxes%bc(n)%field(fms_coupler_ind_flux)%values(i) = 0.0
+                gas_fluxes%bc(n)%field(fms_coupler_ind_flux0)%values(i) = 0.0
+                gas_fluxes%bc(n)%field(fms_coupler_ind_deltap)%values(i) = 0.0
                 cair(i) = 0.0
               endif
             enddo
@@ -157,38 +157,38 @@ contains
             do i = 1, length
               if (seawater(i) == 1.) then
                 !calc_kw(tk,p,u10,h,vb,mw,sc_w,ustar,cd_m)
-                gas_fluxes%bc(n)%field(ind_kw)%values(i) =&
+                gas_fluxes%bc(n)%field(fms_coupler_ind_kw)%values(i) =&
                     & calc_kw(tsurf(i),&
-                    & gas_fields_atm%bc(n)%field(ind_psurf)%values(i),&
-                    & gas_fields_atm%bc(n)%field(ind_u10)%values(i),&
-                    & 101325./(rdgas*wtmair*1e-3*tsurf(i)*max(gas_fields_ice%bc(n)%field(ind_alpha)%values(i),epsln)),&
+                    & gas_fields_atm%bc(n)%field(fms_coupler_ind_psurf)%values(i),&
+                    & gas_fields_atm%bc(n)%field(fms_coupler_ind_u10)%values(i),&
+                    & 101325./(rdgas*wtmair*1e-3*tsurf(i)*max(gas_fields_ice%bc(n)%field(fms_coupler_ind_alpha)%values(i),epsln)),&
                     & gas_fluxes%bc(n)%param(2),&
                     & gas_fluxes%bc(n)%param(1),&
-                    & gas_fields_ice%bc(n)%field(ind_sc_no)%values(i))
+                    & gas_fields_ice%bc(n)%field(fms_coupler_ind_sc_no)%values(i))
                 cair(i) =&
-                    & gas_fields_ice%bc(n)%field(ind_alpha)%values(i) *&
-                    & gas_fields_atm%bc(n)%field(ind_pCair)%values(i) *&
-                    & gas_fields_atm%bc(n)%field(ind_psurf)%values(i) * 9.86923e-6
+                    & gas_fields_ice%bc(n)%field(fms_coupler_ind_alpha)%values(i) *&
+                    & gas_fields_atm%bc(n)%field(fms_coupler_ind_pCair)%values(i) *&
+                    & gas_fields_atm%bc(n)%field(fms_coupler_ind_psurf)%values(i) * 9.86923e-6
                 cair(i) = max(cair(i),0.)
-                gas_fluxes%bc(n)%field(ind_flux)%values(i) =&
-                    & gas_fluxes%bc(n)%field(ind_kw)%values(i) *&
-                    & (max(gas_fields_ice%bc(n)%field(ind_csurf)%values(i),0.) - cair(i))
-                gas_fluxes%bc(n)%field(ind_flux0)%values(i) =&
-                    & gas_fluxes%bc(n)%field(ind_kw)%values(i) *&
-                    & max(gas_fields_ice%bc(n)%field(ind_csurf)%values(i),0.)
-                gas_fluxes%bc(n)%field(ind_deltap)%values(i) =&
-                    & (max(gas_fields_ice%bc(n)%field(ind_csurf)%values(i),0.) - cair(i)) /&
-                    & (gas_fields_ice%bc(n)%field(ind_alpha)%values(i) * permeg + epsln)
+                gas_fluxes%bc(n)%field(fms_coupler_ind_flux)%values(i) =&
+                    & gas_fluxes%bc(n)%field(fms_coupler_ind_kw)%values(i) *&
+                    & (max(gas_fields_ice%bc(n)%field(fms_coupler_ind_csurf)%values(i),0.) - cair(i))
+                gas_fluxes%bc(n)%field(fms_coupler_ind_flux0)%values(i) =&
+                    & gas_fluxes%bc(n)%field(fms_coupler_ind_kw)%values(i) *&
+                    & max(gas_fields_ice%bc(n)%field(fms_coupler_ind_csurf)%values(i),0.)
+                gas_fluxes%bc(n)%field(fms_coupler_ind_deltap)%values(i) =&
+                    & (max(gas_fields_ice%bc(n)%field(fms_coupler_ind_csurf)%values(i),0.) - cair(i)) /&
+                    & (gas_fields_ice%bc(n)%field(fms_coupler_ind_alpha)%values(i) * permeg + epsln)
               else
-                gas_fluxes%bc(n)%field(ind_kw)%values(i) = 0.0
-                gas_fluxes%bc(n)%field(ind_flux)%values(i) = 0.0
-                gas_fluxes%bc(n)%field(ind_flux0)%values(i) = 0.0
-                gas_fluxes%bc(n)%field(ind_deltap)%values(i) = 0.0
+                gas_fluxes%bc(n)%field(fms_coupler_ind_kw)%values(i) = 0.0
+                gas_fluxes%bc(n)%field(fms_coupler_ind_flux)%values(i) = 0.0
+                gas_fluxes%bc(n)%field(fms_coupler_ind_flux0)%values(i) = 0.0
+                gas_fluxes%bc(n)%field(fms_coupler_ind_deltap)%values(i) = 0.0
                 cair(i) = 0.0
               endif
             enddo
           else
-            call mpp_error(FATAL, ' Unknown implementation (' //&
+            call fms_mpp_error(FATAL, ' Unknown implementation (' //&
                 & trim(gas_fluxes%bc(n)%implementation) // ') for ' // trim(gas_fluxes%bc(n)%name))
           endif
         elseif (gas_fluxes%bc(n)%flux_type .eq. 'air_sea_gas_flux') then
@@ -198,21 +198,21 @@ contains
             allocate( kw(length) )
             allocate ( cair(length) )
           elseif (size(kw(:)) .ne. length) then
-            call mpp_error(FATAL, trim(error_header) // ' Lengths of flux fields do not match')
+            call fms_mpp_error(FATAL, trim(error_header) // ' Lengths of flux fields do not match')
           endif
 
           if (gas_fluxes%bc(n)%implementation .eq. 'ocmip2_data') then
             do i = 1, length
               if (seawater(i) == 1.) then
-                kw(i) = gas_fluxes%bc(n)%param(1) * gas_fields_atm%bc(n)%field(ind_u10)%values(i)
+                kw(i) = gas_fluxes%bc(n)%param(1) * gas_fields_atm%bc(n)%field(fms_coupler_ind_u10)%values(i)
                 cair(i) =&
-                    & gas_fields_ice%bc(n)%field(ind_alpha)%values(i) *&
-                    & gas_fields_atm%bc(n)%field(ind_pCair)%values(i) *&
-                    & gas_fields_atm%bc(n)%field(ind_psurf)%values(i) * gas_fluxes%bc(n)%param(2)
-                gas_fluxes%bc(n)%field(ind_flux)%values(i) = kw(i) *&
-                    & (gas_fields_ice%bc(n)%field(ind_csurf)%values(i) - cair(i))
+                    & gas_fields_ice%bc(n)%field(fms_coupler_ind_alpha)%values(i) *&
+                    & gas_fields_atm%bc(n)%field(fms_coupler_ind_pCair)%values(i) *&
+                    & gas_fields_atm%bc(n)%field(fms_coupler_ind_psurf)%values(i) * gas_fluxes%bc(n)%param(2)
+                gas_fluxes%bc(n)%field(fms_coupler_ind_flux)%values(i) = kw(i) *&
+                    & (gas_fields_ice%bc(n)%field(fms_coupler_ind_csurf)%values(i) - cair(i))
               else
-                gas_fluxes%bc(n)%field(ind_flux)%values(i) = 0.0
+                gas_fluxes%bc(n)%field(fms_coupler_ind_flux)%values(i) = 0.0
                 cair(i) = 0.0
                 kw(i) = 0.0
               endif
@@ -220,15 +220,15 @@ contains
           elseif (gas_fluxes%bc(n)%implementation .eq. 'ocmip2') then
             do i = 1, length
               if (seawater(i) == 1.) then
-                kw(i) = gas_fluxes%bc(n)%param(1) * gas_fields_atm%bc(n)%field(ind_u10)%values(i)**2
+                kw(i) = gas_fluxes%bc(n)%param(1) * gas_fields_atm%bc(n)%field(fms_coupler_ind_u10)%values(i)**2
                 cair(i) =&
-                    & gas_fields_ice%bc(n)%field(ind_alpha)%values(i) *&
-                    & gas_fields_atm%bc(n)%field(ind_pCair)%values(i) *&
-                    & gas_fields_atm%bc(n)%field(ind_psurf)%values(i) * gas_fluxes%bc(n)%param(2)
-                gas_fluxes%bc(n)%field(ind_flux)%values(i) = kw(i) *&
-                    & (gas_fields_ice%bc(n)%field(ind_csurf)%values(i) - cair(i))
+                    & gas_fields_ice%bc(n)%field(fms_coupler_ind_alpha)%values(i) *&
+                    & gas_fields_atm%bc(n)%field(fms_coupler_ind_pCair)%values(i) *&
+                    & gas_fields_atm%bc(n)%field(fms_coupler_ind_psurf)%values(i) * gas_fluxes%bc(n)%param(2)
+                gas_fluxes%bc(n)%field(fms_coupler_ind_flux)%values(i) = kw(i) *&
+                    & (gas_fields_ice%bc(n)%field(fms_coupler_ind_csurf)%values(i) - cair(i))
               else
-                gas_fluxes%bc(n)%field(ind_flux)%values(i) = 0.0
+                gas_fluxes%bc(n)%field(fms_coupler_ind_flux)%values(i) = 0.0
                 cair(i) = 0.0
                 kw(i) = 0.0
               endif
@@ -237,21 +237,21 @@ contains
             do i = 1, length
               if (seawater(i) == 1.) then
                 kw(i) = gas_fluxes%bc(n)%param(1) *&
-                    & max(0.0, gas_fields_atm%bc(n)%field(ind_u10)%values(i) - gas_fluxes%bc(n)%param(2))
+                    & max(0.0, gas_fields_atm%bc(n)%field(fms_coupler_ind_u10)%values(i) - gas_fluxes%bc(n)%param(2))
                 cair(i) =&
-                    & gas_fields_ice%bc(n)%field(ind_alpha)%values(i) *&
-                    & gas_fields_atm%bc(n)%field(ind_pCair)%values(i) *&
-                    & gas_fields_atm%bc(n)%field(ind_psurf)%values(i) * gas_fluxes%bc(n)%param(3)
-                gas_fluxes%bc(n)%field(ind_flux)%values(i) = kw(i) *&
-                    & (gas_fields_ice%bc(n)%field(ind_csurf)%values(i) - cair(i))
+                    & gas_fields_ice%bc(n)%field(fms_coupler_ind_alpha)%values(i) *&
+                    & gas_fields_atm%bc(n)%field(fms_coupler_ind_pCair)%values(i) *&
+                    & gas_fields_atm%bc(n)%field(fms_coupler_ind_psurf)%values(i) * gas_fluxes%bc(n)%param(3)
+                gas_fluxes%bc(n)%field(fms_coupler_ind_flux)%values(i) = kw(i) *&
+                    & (gas_fields_ice%bc(n)%field(fms_coupler_ind_csurf)%values(i) - cair(i))
               else
-                gas_fluxes%bc(n)%field(ind_flux)%values(i) = 0.0
+                gas_fluxes%bc(n)%field(fms_coupler_ind_flux)%values(i) = 0.0
                 cair(i) = 0.0
                 kw(i) = 0.0
               endif
             enddo
           else
-            call mpp_error(FATAL, ' Unknown implementation (' //&
+            call fms_mpp_error(FATAL, ' Unknown implementation (' //&
                 & trim(gas_fluxes%bc(n)%implementation) // ') for ' // trim(gas_fluxes%bc(n)%name))
           endif
         elseif (gas_fluxes%bc(n)%flux_type .eq. 'air_sea_deposition') then
@@ -259,7 +259,7 @@ contains
         elseif (gas_fluxes%bc(n)%flux_type .eq. 'land_sea_runoff') then
           if (gas_fluxes%bc(n)%param(1) .le. 0.0) then
             write (error_string, '(1pe10.3)') gas_fluxes%bc(n)%param(1)
-            call mpp_error(FATAL, ' Bad parameter (' // trim(error_string) //&
+            call fms_mpp_error(FATAL, ' Bad parameter (' // trim(error_string) //&
                 & ') for land_sea_runoff for ' // trim(gas_fluxes%bc(n)%name))
           endif
 
@@ -268,19 +268,19 @@ contains
           if (gas_fluxes%bc(n)%implementation .eq. 'river') then
             do i = 1, length
               if (seawater(i) == 1.) then
-                gas_fluxes%bc(n)%field(ind_flux)%values(i) =&
-                    & gas_fields_atm%bc(n)%field(ind_deposition)%values(i) /&
+                gas_fluxes%bc(n)%field(fms_coupler_ind_flux)%values(i) =&
+                    & gas_fields_atm%bc(n)%field(fms_coupler_ind_deposition)%values(i) /&
                     & gas_fluxes%bc(n)%param(1)
               else
-                gas_fluxes%bc(n)%field(ind_flux)%values(i) = 0.0
+                gas_fluxes%bc(n)%field(fms_coupler_ind_flux)%values(i) = 0.0
               endif
             enddo
           else
-            call mpp_error(FATAL, ' Unknown implementation (' //&
+            call fms_mpp_error(FATAL, ' Unknown implementation (' //&
                 & trim(gas_fluxes%bc(n)%implementation) // ') for ' // trim(gas_fluxes%bc(n)%name))
           endif
         else
-          call mpp_error(FATAL, ' Unknown flux_type (' // trim(gas_fluxes%bc(n)%flux_type) //&
+          call fms_mpp_error(FATAL, ' Unknown flux_type (' // trim(gas_fluxes%bc(n)%flux_type) //&
               & ') for ' // trim(gas_fluxes%bc(n)%name))
         endif
       endif

--- a/full/atmos_ocean_fluxes_calc.F90
+++ b/full/atmos_ocean_fluxes_calc.F90
@@ -43,13 +43,13 @@ contains
   !! \throw FATAL, "Unknown flux type ([flux_type]) for [name]"
   subroutine atmos_ocean_fluxes_calc(gas_fields_atm, gas_fields_ice,&
       & gas_fluxes, seawater, tsurf, ustar, cd_m)
-    type(coupler_1d_bc_type), intent(in)    :: gas_fields_atm !< Structure containing atmospheric surface
+    type(fms_coupler_1d_bc_type), intent(in)    :: gas_fields_atm !< Structure containing atmospheric surface
                                                               !! variables that are used in the calculation
                                                               !! of the atmosphere-ocean gas fluxes.
-    type(coupler_1d_bc_type), intent(in)    :: gas_fields_ice !< Structure containing ice-top and ocean
+    type(fms_coupler_1d_bc_type), intent(in)    :: gas_fields_ice !< Structure containing ice-top and ocean
                                                               !! surface variables that are used in the
                                                               !! calculation of the atmosphere-ocean gas fluxes.
-    type(coupler_1d_bc_type), intent(inout) :: gas_fluxes !< Structure containing the gas fluxes between
+    type(fms_coupler_1d_bc_type), intent(inout) :: gas_fluxes !< Structure containing the gas fluxes between
                                                           !! the atmosphere and the ocean and parameters
                                                           !! related to the calculation of these fluxes.
     real, dimension(:), intent(in)           :: seawater  !< 1 for the open water category, 0 if ice or land.

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -1182,7 +1182,7 @@ contains
     integer :: time_stamp_unit !< Unif of the time_stamp file
     integer :: ascii_unit  !< Unit of a dummy ascii file
 
-    type(coupler_1d_bc_type), pointer :: &
+    type(fms_coupler_1d_bc_type), pointer :: &
       gas_fields_atm => NULL(), &  ! A pointer to the type describing the
               ! atmospheric fields that will participate in the gas fluxes.
       gas_fields_ocn => NULL(), &  ! A pointer to the type describing the ocean

--- a/full/flux_exchange.F90
+++ b/full/flux_exchange.F90
@@ -591,15 +591,15 @@ module flux_exchange_mod
        & partition_fprec_from_lprec, scale_precip_2d
 
   logical :: gas_fluxes_initialized = .false.  ! This is set to true when the following types are initialized.
-  type(coupler_1d_bc_type), target :: ex_gas_fields_atm  ! gas fields in atm
+  type(fms_coupler_1d_bc_type), target :: ex_gas_fields_atm  ! gas fields in atm
       !< Structure containing atmospheric surfacevariables that are used in the
       !! calculation of the atmosphere-ocean gas fluxes, as well as parameters
       !! regulating these fluxes.
-  type(coupler_1d_bc_type), target :: ex_gas_fields_ice  ! gas fields atop the ice or ocean
+  type(fms_coupler_1d_bc_type), target :: ex_gas_fields_ice  ! gas fields atop the ice or ocean
       !< Structure containing ice-top and ocean surface variables that are used
       !! in the calculation of the atmosphere-ocean gas fluxes, as well as parameters
       !! regulating these fluxes.
-  type(coupler_1d_bc_type), target :: ex_gas_fluxes      ! gas fluxes between the atm and ocean
+  type(fms_coupler_1d_bc_type), target :: ex_gas_fluxes      ! gas fluxes between the atm and ocean
       !< A structure for exchanging gas or tracer fluxes between the atmosphere and ocean,
       !! defined by the field table, as well as a place holder of intermediate calculations,
       !! such as piston velocities, and parameters that impact the fluxes.
@@ -624,15 +624,15 @@ contains
   !! ex_gas_fluxes and ex_gas_fields arrays, although the data is not allocated yet.
   !! This is intended to be called (optionally) prior to flux_exchange_init.
   subroutine gas_exchange_init (gas_fields_atm, gas_fields_ice, gas_fluxes)
-    type(coupler_1d_bc_type), optional, pointer :: gas_fields_atm
+    type(fms_coupler_1d_bc_type), optional, pointer :: gas_fields_atm
       !< Pointer to a structure containing atmospheric surface variables that
       !! are used in the calculation of the atmosphere-ocean gas fluxes, as well
       !! as parameters regulating these fluxes.
-    type(coupler_1d_bc_type), optional, pointer :: gas_fields_ice
+    type(fms_coupler_1d_bc_type), optional, pointer :: gas_fields_ice
       !< Pointer to a structure containing ice-top and ocean surface variables
       !! that are used in the calculation of the atmosphere-ocean gas fluxes,
       !! as well as parameters regulating these fluxes.
-    type(coupler_1d_bc_type), optional, pointer :: gas_fluxes
+    type(fms_coupler_1d_bc_type), optional, pointer :: gas_fluxes
       !< Pointer to a s structure for exchanging gas or tracer fluxes between the
       !! atmosphere and ocean, defined by the field table, as well as a place holder
       !! of intermediate calculations, such as piston velocities, and parameters

--- a/full/flux_exchange.F90
+++ b/full/flux_exchange.F90
@@ -591,15 +591,15 @@ module flux_exchange_mod
        & partition_fprec_from_lprec, scale_precip_2d
 
   logical :: gas_fluxes_initialized = .false.  ! This is set to true when the following types are initialized.
-  type(fms_coupler_1d_bc_type), target :: ex_gas_fields_atm  ! gas fields in atm
+  type(FmsCoupler1dBC_type), target :: ex_gas_fields_atm  ! gas fields in atm
       !< Structure containing atmospheric surfacevariables that are used in the
       !! calculation of the atmosphere-ocean gas fluxes, as well as parameters
       !! regulating these fluxes.
-  type(fms_coupler_1d_bc_type), target :: ex_gas_fields_ice  ! gas fields atop the ice or ocean
+  type(FmsCoupler1dBC_type), target :: ex_gas_fields_ice  ! gas fields atop the ice or ocean
       !< Structure containing ice-top and ocean surface variables that are used
       !! in the calculation of the atmosphere-ocean gas fluxes, as well as parameters
       !! regulating these fluxes.
-  type(fms_coupler_1d_bc_type), target :: ex_gas_fluxes      ! gas fluxes between the atm and ocean
+  type(FmsCoupler1dBC_type), target :: ex_gas_fluxes      ! gas fluxes between the atm and ocean
       !< A structure for exchanging gas or tracer fluxes between the atmosphere and ocean,
       !! defined by the field table, as well as a place holder of intermediate calculations,
       !! such as piston velocities, and parameters that impact the fluxes.
@@ -624,15 +624,15 @@ contains
   !! ex_gas_fluxes and ex_gas_fields arrays, although the data is not allocated yet.
   !! This is intended to be called (optionally) prior to flux_exchange_init.
   subroutine gas_exchange_init (gas_fields_atm, gas_fields_ice, gas_fluxes)
-    type(fms_coupler_1d_bc_type), optional, pointer :: gas_fields_atm
+    type(FmsCoupler1dBC_type), optional, pointer :: gas_fields_atm
       !< Pointer to a structure containing atmospheric surface variables that
       !! are used in the calculation of the atmosphere-ocean gas fluxes, as well
       !! as parameters regulating these fluxes.
-    type(fms_coupler_1d_bc_type), optional, pointer :: gas_fields_ice
+    type(FmsCoupler1dBC_type), optional, pointer :: gas_fields_ice
       !< Pointer to a structure containing ice-top and ocean surface variables
       !! that are used in the calculation of the atmosphere-ocean gas fluxes,
       !! as well as parameters regulating these fluxes.
-    type(fms_coupler_1d_bc_type), optional, pointer :: gas_fluxes
+    type(FmsCoupler1dBC_type), optional, pointer :: gas_fluxes
       !< Pointer to a s structure for exchanging gas or tracer fluxes between the
       !! atmosphere and ocean, defined by the field table, as well as a place holder
       !! of intermediate calculations, such as piston velocities, and parameters
@@ -671,7 +671,7 @@ contains
        land_ice_boundary, ice_ocean_boundary, ocean_ice_boundary, &
        do_ocean, slow_ice_ocean_pelist, dt_atmos, dt_cpld )
 
-    type(time_type),                   intent(in)     :: Time !< The model's current time
+    type(FmsTime_type),                   intent(in)     :: Time !< The model's current time
     type(atmos_data_type),             intent(inout)  :: Atm !< A derived data type to specify atmosphere boundary data
     type(land_data_type),              intent(in)     :: Land !< A derived data type to specify land boundary data
     type(ice_data_type),               intent(inout)  :: Ice !< A derived data type to specify ice boundary data
@@ -714,7 +714,7 @@ contains
     !       be meaningfully set from the atmospheric model (not from the field table)
     !
 
-    call fms_sat_vapor_pres_sat_vapor_pres_init()
+    call fms_sat_vapor_pres_init()
 
     nthreads = 1
     ! assign nblocks to number of threads.
@@ -724,15 +724,15 @@ contains
     nblocks = nthreads
 
     !-----------------------------------------------------------------------
-    logunit = stdlog()
+    logunit = fms_mpp_stdlog()
     !----- read namelist -------
 
-    read (input_nml_file, flux_exchange_nml, iostat=io)
+    read (fms_mpp_input_nml_file, flux_exchange_nml, iostat=io)
     ierr = check_nml_error (io, 'flux_exchange_nml')
 
     !----- write namelist to logfile -----
     call fms_write_version_number (version, tag)
-    if( mpp_pe() == mpp_root_pe() )write( logunit, nml=flux_exchange_nml )
+    if( fms_mpp_pe() == fms_mpp_root_pe() )write( logunit, nml=flux_exchange_nml )
     if(nblocks<1) call error_mesg ('flux_exchange_mod',  &
          'flux_exchange_nml nblocks must be positive', FATAL)
     if(nblocks .NE. nthreads) then
@@ -752,7 +752,7 @@ contains
 
     if( Atm%pe )then
        call fms_mpp_set_current_pelist(Atm%pelist)
-       cplClock = mpp_clock_id( 'Land-ice-atm coupler', flags=clock_flag_default, grain=CLOCK_COMPONENT )
+       cplClock = fms_mpp_clock_id( 'Land-ice-atm coupler', flags=fms_clock_flag_default, grain=CLOCK_COMPONENT )
        call check_atm_grid(Atm, grid_file)
        call atm_land_ice_flux_exchange_init(Time, Atm, Land, Ice, atmos_ice_boundary, land_ice_atmos_boundary, &
             Dt_atm, Dt_cpl, z_ref_heat, z_ref_mom, ex_u_star_smooth_bug,  &
@@ -780,7 +780,7 @@ contains
 
   subroutine flux_check_stocks(Time, Atm, Lnd, Ice, Ocn_state)
 
-    type(time_type)                           :: Time
+    type(FmsTime_type)                           :: Time
     type(atmos_data_type), optional           :: Atm
     type(land_data_type), optional            :: Lnd
     type(ice_data_type), optional             :: Ice
@@ -805,29 +805,29 @@ contains
              ref_value = ref_value + ATM_PRECIP_NEW
           endif
 
-          Atm_stock(i)%q_now = ref_value
+          fms_stock_constants_atm_stock(i)%q_now = ref_value
        endif
 
        if(present(Lnd)) then
           ref_value = 0.0
           call Lnd_stock_pe(Lnd, index=i, value=ref_value)
-          Lnd_stock(i)%q_now = ref_value
+          fms_stock_constants_lnd_stock(i)%q_now = ref_value
        endif
 
        if(present(Ice)) then
           ref_value = 0.0
           call Ice_stock_pe(Ice, index=i, value=ref_value)
-          Ice_stock(i)%q_now = ref_value
+          fms_stock_constants_ice_stock(i)%q_now = ref_value
        endif
 
        if(present(Ocn_state)) then
           ref_value = 0.0
           call Ocean_stock_pe(Ocn_state, index=i, value=ref_value)
-          Ocn_stock(i)%q_now = ref_value
+          fms_stock_constants_ocn_stock(i)%q_now = ref_value
        endif
     enddo
 
-    call fms_stock_constant_stocks_report(Time)
+    call fms_stock_constants_stocks_report(Time)
 
 
   end subroutine flux_check_stocks
@@ -839,7 +839,7 @@ contains
   !! the initial stock values.
 
   subroutine flux_init_stocks(Time, Atm, Lnd, Ice, Ocn_state)
-    type(time_type) , intent(in) :: Time
+    type(FmsTime_type) , intent(in) :: Time
     type(atmos_data_type)        :: Atm
     type(land_data_type)         :: Lnd
     type(ice_data_type)          :: Ice
@@ -847,24 +847,24 @@ contains
 
     integer :: i
 
-    stocks_file=stdout()
+    fms_stock_constants_stocks_file=fms_mpp_stdout()
     ! If the divert_stocks_report is set to true, write the stocks to a new file "stocks.out"
-    if(mpp_pe()==mpp_root_pe() .and. divert_stocks_report) then
-       open(newunit = stocks_file, file='stocks.out', status='replace', form='formatted')
+    if(fms_mpp_pe()==fms_mpp_root_pe() .and. divert_stocks_report) then
+       open(newunit = fms_stock_constants_stocks_file, file='stocks.out', status='replace', form='formatted')
     endif
 
     ! Initialize stock values
     do i = 1, NELEMS
-       call Atm_stock_pe(   Atm , index=i, value=Atm_stock(i)%q_start)
+       call Atm_stock_pe(   Atm , index=i, value=fms_stock_constants_atm_stock(i)%q_start)
 
        if(i==ISTOCK_WATER .and. Atm%pe ) then
           call atm_stock_integrate(Atm, ATM_PRECIP_NEW)
-          Atm_stock(i)%q_start = Atm_stock(i)%q_start + ATM_PRECIP_NEW
+          fms_stock_constants_atm_stock(i)%q_start = fms_stock_constants_atm_stock(i)%q_start + ATM_PRECIP_NEW
        endif
 
-       call Lnd_stock_pe(   Lnd , index=i, value=Lnd_stock(i)%q_start)
-       call Ice_stock_pe(   Ice , index=i, value=Ice_stock(i)%q_start)
-       call Ocean_stock_pe( Ocn_state , index=i, value=Ocn_stock(i)%q_start)
+       call Lnd_stock_pe(   Lnd , index=i, value=fms_stock_constants_lnd_stock(i)%q_start)
+       call Ice_stock_pe(   Ice , index=i, value=fms_stock_constants_ice_stock(i)%q_start)
+       call Ocean_stock_pe( Ocn_state , index=i, value=fms_stock_constants_ocn_stock(i)%q_start)
     enddo
 
 
@@ -884,7 +884,7 @@ contains
     integer        :: nxg, nyg, ioff, joff
     integer        :: nlon, nlat, siz(4)
     integer        :: i, j
-    type(domain2d) :: domain2
+    type(FmsMppDomain2D) :: domain2
     real, dimension(:,:), allocatable :: tmpx, tmpy
     real, dimension(:),   allocatable :: atmlonb, atmlatb
     character(len=256)              :: atm_mosaic_file, tile_file, buffer
@@ -900,10 +900,10 @@ contains
     call fms_mpp_domains_get_data_domain(Atm%domain, isd, ied, jsd, jed)
 
     !< Open the grid files with pelist argument so that only one pes open/reads the file
-    allocate(pes(mpp_npes()))
+    allocate(pes(fms_mpp_npes()))
     call fms_mpp_get_current_pelist(pes)
 
-    if ( .not. open_file(grid_file_obj, grid_file, "read", pelist=pes)) then
+    if ( .not. fms2_io_open_file(grid_file_obj, grid_file, "read", pelist=pes)) then
          call error_mesg ('atm_land_ice_flux_exchange_mod',  &
               & 'Error opening '//trim(grid_file), FATAL)
     endif
@@ -915,13 +915,13 @@ contains
     ioff = lbound(Atm%lon_bnd,1) - isc
     joff = lbound(Atm%lon_bnd,2) - jsc
 
-    if(variable_exists(grid_file_obj, "AREA_ATM" ) ) then  ! old grid
-       call fms_fms2_io_get_variable_size(grid_file_obj, "AREA_ATM", siz(1:2))
+    if(fms2_io_variable_exists(grid_file_obj, "AREA_ATM" ) ) then  ! old grid
+       call fms2_io_get_variable_size(grid_file_obj, "AREA_ATM", siz(1:2))
        nlon = siz(1)
        nlat = siz(2)
 
        if (nlon /= nxg .or. nlat /= nyg) then
-          if (mpp_pe()==mpp_root_pe()) then
+          if (fms_mpp_pe()==fms_mpp_root_pe()) then
              print *, 'grid_spec.nc has', nlon, 'longitudes,', nlat, 'latitudes; ', &
                   'atmosphere has', nxg, 'longitudes,', &
                   nyg, 'latitudes (see xba.dat and yba.dat)'
@@ -931,8 +931,8 @@ contains
        end if
        allocate( atmlonb(isg:ieg+1) )
        allocate( atmlatb(jsg:jeg+1) )
-       call fms_fms2_io_read_data(grid_file_obj, 'xba', atmlonb)
-       call fms_fms2_io_read_data(grid_file_obj, 'yba', atmlatb)
+       call fms2_io_read_data(grid_file_obj, 'xba', atmlonb)
+       call fms2_io_read_data(grid_file_obj, 'yba', atmlatb)
 
        do i=isc, iec+1
           if(abs(atmlonb(i)-Atm%lon_bnd(i+ioff,jsc+joff)*45.0/atan(1.0))>bound_tol) then
@@ -953,15 +953,15 @@ contains
           endif
        enddo
        deallocate(atmlonb, atmlatb)
-    else if(variable_exists(grid_file_obj, "atm_mosaic_file" ) ) then  ! mosaic grid file.
-       call fms_fms2_io_read_data(grid_file_obj, 'atm_mosaic_file', atm_mosaic_file)
+    else if(fms2_io_variable_exists(grid_file_obj, "atm_mosaic_file" ) ) then  ! mosaic grid file.
+       call fms2_io_read_data(grid_file_obj, 'atm_mosaic_file', atm_mosaic_file)
 
-       if ( .not. open_file(atm_mosaic_file_obj, "INPUT/"//trim(atm_mosaic_file)//"", "read", pelist=pes)) then
+       if ( .not. fms2_io_open_file(atm_mosaic_file_obj, "INPUT/"//trim(atm_mosaic_file)//"", "read", pelist=pes)) then
            call error_mesg ('atm_land_ice_flux_exchange_mod',  &
               & 'Error opening '//trim(atm_mosaic_file), FATAL)
        endif
 
-       call fms_fms2_io_read_data(atm_mosaic_file_obj, "gridfiles", buffer, corner=1)
+       call fms2_io_read_data(atm_mosaic_file_obj, "gridfiles", buffer, corner=1)
 
        !< Remove the .tile from the filename to get basename
        ppos = index(trim(buffer),".tile")
@@ -971,7 +971,7 @@ contains
           tile_file = buffer
        endif
 
-       call fms_fms2_io_close_file(atm_mosaic_file_obj)
+       call fms2_io_close_file(atm_mosaic_file_obj)
 
        call fms_mpp_domains_copy_domain(Atm%domain, domain2)
        call fms_mpp_domains_create_super_grid_domain(domain2)
@@ -980,25 +980,25 @@ contains
        call fms_mpp_domains_get_compute_domain(domain2, isc2, iec2, jsc2, jec2)
 
        if(isc2 .NE. 2*isc-1 .OR. iec2 .NE. 2*iec+1 .OR. jsc2 .NE. 2*jsc-1 .OR. jec2 .NE. 2*jec+1) then
-          call mpp_error(FATAL, 'atm_land_ice_flux_exchange_mod: supergrid domain is not set properly')
+          call fms_mpp_error(FATAL, 'atm_land_ice_flux_exchange_mod: supergrid domain is not set properly')
        endif
 
        !< This is will open the correct atm_mosaic_file for the current tile, i.e "C96_grid.tile1.nc"
-       if ( .not. open_file(tile_file_obj, "INPUT/"//trim(tile_file)//"", "read", domain2)) then
+       if ( .not. fms2_io_open_file(tile_file_obj, "INPUT/"//trim(tile_file)//"", "read", domain2)) then
           call error_mesg ('atm_land_ice_flux_exchange_mod',  &
               & 'Error opening '//trim(tile_file), FATAL)
        endif
 
-       call fms_fms2_io_get_variable_size(tile_file_obj, 'area', siz(1:2))
+       call fms2_io_get_variable_size(tile_file_obj, 'area', siz(1:2))
        nlon = siz(1); nlat = siz(2)
-       if( mod(nlon,2) .NE. 0) call mpp_error(FATAL,  &
+       if( mod(nlon,2) .NE. 0) call fms_mpp_error(FATAL,  &
             'atm_land_ice_flux_exchange_mod: atmos supergrid longitude size can not be divided by 2')
-       if( mod(nlat,2) .NE. 0) call mpp_error(FATAL,  &
+       if( mod(nlat,2) .NE. 0) call fms_mpp_error(FATAL,  &
             'atm_land_ice_flux_exchange_mod: atmos supergrid latitude size can not be divided by 2')
        nlon = nlon/2
        nlat = nlat/2
        if (nlon /= nxg .or. nlat /= nyg) then
-          if (mpp_pe()==mpp_root_pe()) then
+          if (fms_mpp_pe()==fms_mpp_root_pe()) then
              print *, 'atmosphere mosaic tile has', nlon, 'longitudes,', nlat, 'latitudes; ', &
                   'atmosphere has', nxg, 'longitudes,', nyg, 'latitudes'
           end if
@@ -1009,17 +1009,17 @@ contains
        allocate(tmpx(isc2:iec2,jsc2:jec2), tmpy(isc2:iec2,jsc2:jec2) )
 
        !< Register the dimension of the variables "x" and "y" in the atm_mosaic_file
-       call fms_fms2_io_get_variable_dimension_names(tile_file_obj, "x", dim_names)
-       call fms_fms2_io_register_axis(tile_file_obj, dim_names(1), "x")
-       call fms_fms2_io_register_axis(tile_file_obj, dim_names(2), "y")
-       call fms_fms2_io_register_field(tile_file_obj, "x", "double", dim_names)
-       call fms_fms2_io_register_field(tile_file_obj, "y", "double", dim_names)
+       call fms2_io_get_variable_dimension_names(tile_file_obj, "x", dim_names)
+       call fms2_io_register_axis(tile_file_obj, dim_names(1), "x")
+       call fms2_io_register_axis(tile_file_obj, dim_names(2), "y")
+       call fms2_io_register_field(tile_file_obj, "x", "double", dim_names)
+       call fms2_io_register_field(tile_file_obj, "y", "double", dim_names)
 
        !< Read the variables "x" and "y" as domain decomposed variables from the atm_moasic_file
-       call fms_fms2_io_read_data( tile_file_obj, 'x', tmpx)
-       call fms_fms2_io_read_data( tile_file_obj, 'y', tmpy)
+       call fms2_io_read_data( tile_file_obj, 'x', tmpx)
+       call fms2_io_read_data( tile_file_obj, 'y', tmpy)
 
-       call fms_fms2_io_close_file(tile_file_obj)
+       call fms2_io_close_file(tile_file_obj)
 
        call fms_mpp_domains_deallocate_domain(domain2)
 
@@ -1043,10 +1043,10 @@ contains
        end do
        deallocate(tmpx, tmpy)
     else
-       call mpp_error(FATAL, 'atm_land_ice_flux_exchange_mod: both AREA_ATMxOCN and ocn_mosaic_file does not exist in '//trim(grid_file))
+       call fms_mpp_error(FATAL, 'atm_land_ice_flux_exchange_mod: both AREA_ATMxOCN and ocn_mosaic_file does not exist in '//trim(grid_file))
     end if
 
-    call fms_fms2_io_close_file(grid_file_obj)
+    call fms2_io_close_file(grid_file_obj)
   end subroutine check_atm_grid
 
 end module flux_exchange_mod

--- a/full/land_ice_flux_exchange.F90
+++ b/full/land_ice_flux_exchange.F90
@@ -64,7 +64,7 @@ contains
     fluxLandIceClock = mpp_clock_id( 'Flux land to ice', flags=clock_flag_default, grain=CLOCK_ROUTINE )
 
     if (do_runoff) then
-       call setup_xmap(xmap_runoff, (/ 'LND', 'OCN' /),       &
+       call fms_xgrid_setup_xmap(xmap_runoff, (/ 'LND', 'OCN' /),       &
             (/ Land%Domain, Ice%Domain /),                    &
             "INPUT/grid_spec.nc"             )
        ! exchange grid indices
@@ -73,7 +73,7 @@ contains
        if (n_xgrid_runoff.eq.1) write (*,'(a,i6,6x,a)') 'PE = ', mpp_pe(), 'Runoff  exchange size equals one.'
     endif
 
-    call mpp_get_compute_domain( Ice%domain, is, ie, js, je )
+    call fms_mpp_domains_get_compute_domain( Ice%domain, is, ie, js, je )
 
     !allocate land_ice_boundary
     allocate( land_ice_boundary%runoff(is:ie,js:je) )
@@ -113,34 +113,34 @@ contains
     real, dimension(size(Land_Ice_Boundary%runoff,1),size(Land_Ice_Boundary%runoff,2),1) :: ice_buf
 
     !Balaji
-    call mpp_clock_begin(cplClock)
-    call mpp_clock_begin(fluxLandIceClock)
+    call fms_mpp_clock_begin(cplClock)
+    call fms_mpp_clock_begin(fluxLandIceClock)
 
     ! ccc = conservation_check(Land%discharge, 'LND', xmap_runoff)
     ! if (mpp_pe()==mpp_root_pe()) print *,'RUNOFF', ccc
 
     if (do_runoff) then
-       call put_to_xgrid ( Land%discharge,      'LND', ex_runoff,  xmap_runoff)
-       call put_to_xgrid ( Land%discharge_snow, 'LND', ex_calving, xmap_runoff)
-       call put_to_xgrid ( Land%discharge_heat,      'LND', ex_runoff_hflx,  xmap_runoff)
-       call put_to_xgrid ( Land%discharge_snow_heat, 'LND', ex_calving_hflx, xmap_runoff)
-       call get_from_xgrid (ice_buf, 'OCN', ex_runoff,  xmap_runoff)
+       call fms_xgrid_put_to_xgrid ( Land%discharge,      'LND', ex_runoff,  xmap_runoff)
+       call fms_xgrid_put_to_xgrid ( Land%discharge_snow, 'LND', ex_calving, xmap_runoff)
+       call fms_xgrid_put_to_xgrid ( Land%discharge_heat,      'LND', ex_runoff_hflx,  xmap_runoff)
+       call fms_xgrid_put_to_xgrid ( Land%discharge_snow_heat, 'LND', ex_calving_hflx, xmap_runoff)
+       call fms_xgrid_get_from_xgrid (ice_buf, 'OCN', ex_runoff,  xmap_runoff)
        Land_Ice_Boundary%runoff = ice_buf(:,:,1);
-       call get_from_xgrid (ice_buf, 'OCN', ex_calving, xmap_runoff)
+       call fms_xgrid_get_from_xgrid (ice_buf, 'OCN', ex_calving, xmap_runoff)
        Land_Ice_Boundary%calving = ice_buf(:,:,1);
-       call get_from_xgrid (ice_buf, 'OCN', ex_runoff_hflx,  xmap_runoff)
+       call fms_xgrid_get_from_xgrid (ice_buf, 'OCN', ex_runoff_hflx,  xmap_runoff)
        Land_Ice_Boundary%runoff_hflx = ice_buf(:,:,1);
-       call get_from_xgrid (ice_buf, 'OCN', ex_calving_hflx, xmap_runoff)
+       call fms_xgrid_get_from_xgrid (ice_buf, 'OCN', ex_calving_hflx, xmap_runoff)
        Land_Ice_Boundary%calving_hflx = ice_buf(:,:,1);
        !Balaji
-       call data_override('ICE', 'runoff' , Land_Ice_Boundary%runoff , Time)
-       call data_override('ICE', 'calving', Land_Ice_Boundary%calving, Time)
-       call data_override('ICE', 'runoff_hflx' , Land_Ice_Boundary%runoff_hflx , Time)
-       call data_override('ICE', 'calving_hflx', Land_Ice_Boundary%calving_hflx, Time)
+       call fms_data_override('ICE', 'runoff' , Land_Ice_Boundary%runoff , Time)
+       call fms_data_override('ICE', 'calving', Land_Ice_Boundary%calving, Time)
+       call fms_data_override('ICE', 'runoff_hflx' , Land_Ice_Boundary%runoff_hflx , Time)
+       call fms_data_override('ICE', 'calving_hflx', Land_Ice_Boundary%calving_hflx, Time)
 
        ! compute stock increment
        ice_buf(:,:,1) = Land_Ice_Boundary%runoff + Land_Ice_Boundary%calving
-       call stock_move(from=Lnd_stock(ISTOCK_WATER), to=Ice_stock(ISTOCK_WATER), &
+       call fms_xgrid_stock_move(from=Lnd_stock(ISTOCK_WATER), to=Ice_stock(ISTOCK_WATER), &
             & grid_index=X2_GRID_ICE, &
             & data=ice_buf, &
             & xmap=xmap_runoff, &
@@ -154,8 +154,8 @@ contains
        Land_Ice_Boundary%calving_hflx = 0.0
     endif
 
-    call mpp_clock_end(fluxLandIceClock)
-    call mpp_clock_end(cplClock)
+    call fms_mpp_clock_end(fluxLandIceClock)
+    call fms_mpp_clock_end(cplClock)
 
   end subroutine flux_land_to_ice
 

--- a/shared/surface_flux.F90
+++ b/shared/surface_flux.F90
@@ -288,8 +288,8 @@ subroutine surface_flux_1d (                                           &
 
   t_surf1 = t_surf0 + del_temp
 
-  call escomp ( t_surf0, e_sat  )  ! saturation vapor pressure
-  call escomp ( t_surf1, e_sat1 )  ! perturbed  vapor pressure
+  call fms_sat_vapor_pres_escomp ( t_surf0, e_sat  )  ! saturation vapor pressure
+  call fms_sat_vapor_pres_escomp ( t_surf1, e_sat1 )  ! perturbed  vapor pressure
 
   if(use_mixing_ratio) then
     ! surface mixing ratio at saturation
@@ -366,7 +366,7 @@ subroutine surface_flux_1d (                                           &
   endif
 
   !  monin-obukhov similarity theory
-  call mo_drag (thv_atm, thv_surf, z_atm,                  &
+  call fms_monin_obukhov_mo_drag (thv_atm, thv_surf, z_atm,                  &
        rough_mom, rough_heat, rough_moist, w_atm,          &
        cd_m, cd_t, cd_q, u_star, b_star, avail             )
 
@@ -685,14 +685,14 @@ subroutine surface_flux_init
   ierr = check_nml_error(io,'surface_flux_nml')
 
   ! write version number
-  call write_version_number(version, tagname)
+  call fms_write_version_number(version, tagname)
 
   unit = stdlog()
   if ( mpp_pe() == mpp_root_pe() )  write (unit, nml=surface_flux_nml)
 
   if(.not. use_virtual_temp) d608 = 0.0
 
-  call monin_obukhov_init()
+  call fms_monin_obukhov_init()
 
   module_is_initialized = .true.
 

--- a/shared/surface_flux.F90
+++ b/shared/surface_flux.F90
@@ -273,7 +273,7 @@ subroutine surface_flux_1d (                                           &
 
 
   if (.not. module_is_initialized) &
-     call mpp_error(FATAL, "surface_flux_1d: surface_flux_init is not called")
+     call fms_mpp_error(FATAL, "surface_flux_1d: surface_flux_init is not called")
 
   !---- use local value of surf temp ----
 
@@ -681,14 +681,14 @@ subroutine surface_flux_init
   integer :: unit, ierr, io
 
   ! read namelist
-  read (input_nml_file, surface_flux_nml, iostat=io)
+  read (fms_mpp_input_nml_file, surface_flux_nml, iostat=io)
   ierr = check_nml_error(io,'surface_flux_nml')
 
   ! write version number
   call fms_write_version_number(version, tagname)
 
-  unit = stdlog()
-  if ( mpp_pe() == mpp_root_pe() )  write (unit, nml=surface_flux_nml)
+  unit = fms_mpp_stdlog()
+  if ( fms_mpp_pe() == fms_mpp_root_pe() )  write (unit, nml=surface_flux_nml)
 
   if(.not. use_virtual_temp) d608 = 0.0
 

--- a/simple/coupler_main.F90
+++ b/simple/coupler_main.F90
@@ -95,7 +95,7 @@ implicit none
 !-----------------------------------------------------------------------
 ! ----- coupled model time -----
 
-   type (time_type) :: Time_atmos, Time_init, Time_end,  &
+   type (FmsTime_type) :: Time_atmos, Time_init, Time_end,  &
                        Time_step_atmos, Time_step_ocean
    integer :: num_cpld_calls, num_atmos_calls, nc, na
 
@@ -140,9 +140,9 @@ implicit none
 
    call fms_init()
    call fms_mpp_init()
-   initClock = mpp_clock_id( 'Initialization' )
-   mainClock = mpp_clock_id( 'Main loop' )
-   termClock = mpp_clock_id( 'Termination' )
+   initClock = fms_mpp_clock_id( 'Initialization' )
+   mainClock = fms_mpp_clock_id( 'Main loop' )
+   termClock = fms_mpp_clock_id( 'Termination' )
    call fms_mpp_clock_begin (initClock)
 
    call fms_init
@@ -250,7 +250,7 @@ contains
     integer :: total_days, total_seconds, ierr, io
     integer :: n, gnlon, gnlat
     integer :: date(6), flags
-    type (time_type) :: Run_length
+    type (FmsTime_type) :: Run_length
     character(len=9) :: month
     logical :: use_namelist
 
@@ -266,22 +266,22 @@ contains
 !----- read namelist -------
 !----- for backwards compatibilty read from file coupler.nml -----
 
-    read (input_nml_file, nml=coupler_nml, iostat=io)
+    read (fms_mpp_input_nml_file, nml=coupler_nml, iostat=io)
     ierr = check_nml_error(io, 'coupler_nml')
 
 !----- write namelist to logfile -----
 
     call fms_write_version_number (version, tag)
-    if (mpp_pe() == mpp_root_pe()) write(stdlog(),nml=coupler_nml)
+    if (fms_mpp_pe() == fms_mpp_root_pe()) write(fms_mpp_stdlog(),nml=coupler_nml)
 
 !----- allocate and set the pelist (to the global pelist) -----
-    allocate( Atm%pelist  (mpp_npes()) )
+    allocate( Atm%pelist  (fms_mpp_npes()) )
     call fms_mpp_get_current_pelist(Atm%pelist)
 
 !----- read restart file -----
 
-    if (file_exists('INPUT/coupler.res')) then
-       call fms_fms2_io_ascii_read('INPUT/coupler.res', restart_file)
+    if (fms2_io_file_exists('INPUT/coupler.res')) then
+       call fms2_io_ascii_read('INPUT/coupler.res', restart_file)
        read(restart_file(1), *) calendar_type
        read(restart_file(2), *) date_init
        read(restart_file(3), *) date
@@ -303,7 +303,7 @@ contains
 
 !----- override calendar type with namelist value -----
 
-      select case( uppercase(trim(calendar)) )
+      select case( fms_mpp_uppercase(trim(calendar)) )
       case( 'GREGORIAN' )
           calendar_type = GREGORIAN
       case( 'JULIAN' )
@@ -315,7 +315,7 @@ contains
       case( 'NO_CALENDAR' )
           calendar_type = NO_CALENDAR
       case default
-          call mpp_error ( FATAL, 'COUPLER_MAIN: coupler_nml entry calendar must '// &
+          call fms_mpp_error ( FATAL, 'COUPLER_MAIN: coupler_nml entry calendar must '// &
                                   'be one of GREGORIAN|JULIAN|NOLEAP|THIRTY_DAY|NO_CALENDAR.' )
       end select
 
@@ -325,8 +325,8 @@ contains
 
 !----- write current/initial date actually used to logfile file -----
 
-    if ( mpp_pe() == mpp_root_pe() ) then
-      write (stdlog(),16) date(1),trim(month_name(date(2))),date(3:6)
+    if ( fms_mpp_pe() == fms_mpp_root_pe() ) then
+      write (fms_mpp_stdlog(),16) date(1),trim(fms_time_manager_month_name(date(2))),date(3:6)
     endif
 
  16 format ('  current date used = ',i4,1x,a,2i3,2(':',i2.2),' gmt')
@@ -338,11 +338,11 @@ contains
 !-----------------------------------------------------------------------
 !------ initialize diagnostics manager ------
 
-    call fms_diag_manager_init
+    call fms_diag_init
 
 !----- always override initial/base date with diag_manager value -----
 
-    call fms_diag_manager_get_base_date ( date_init(1), date_init(2), date_init(3), &
+    call fms_diag_get_base_date ( date_init(1), date_init(2), date_init(3), &
                          date_init(4), date_init(5), date_init(6)  )
 
 !----- use current date if no base date ------
@@ -351,10 +351,10 @@ contains
 
 !----- set initial and current time types ------
 
-    Time_init  = set_date (date_init(1), date_init(2), date_init(3), &
+    Time_init  = fms_time_manager_set_date (date_init(1), date_init(2), date_init(3), &
                            date_init(4), date_init(5), date_init(6))
 
-    Time_atmos = set_date (date(1), date(2), date(3),  &
+    Time_atmos = fms_time_manager_set_date (date(1), date(2), date(3),  &
                            date(4), date(5), date(6))
 
 !-----------------------------------------------------------------------
@@ -369,40 +369,40 @@ contains
     Time_end = Time_atmos
     total_days = 0
     do n = 1, months
-      total_days = total_days + days_in_month(Time_end)
-      Time_end = Time_atmos + set_time (0,total_days)
+      total_days = total_days + fms_time_manager_days_in_month(Time_end)
+      Time_end = Time_atmos + fms_time_manager_set_time (0,total_days)
     enddo
 
     total_days    = total_days + days
     total_seconds = hours*3600 + minutes*60 + seconds
-    Run_length    = set_time (total_seconds,total_days)
+    Run_length    = fms_time_manager_set_time (total_seconds,total_days)
     Time_end      = Time_atmos + Run_length
 
     !Need to pass Time_end into diag_manager for multiple thread case.
-    call fms_diag_manager_set_time_end(Time_end)
+    call fms_diag_set_time_end(Time_end)
 
 
 !-----------------------------------------------------------------------
 !----- write time stamps (for start time and end time) ------
-    if ( mpp_pe().EQ.mpp_root_pe() ) open(newunit = time_stamp_unit, file='time_stamp.out', status='replace', form='formatted')
+    if ( fms_mpp_pe().EQ.fms_mpp_root_pe() ) open(newunit = time_stamp_unit, file='time_stamp.out', status='replace', form='formatted')
 
-    month = month_name(date(2))
-    if ( mpp_pe() == mpp_root_pe() ) write (time_stamp_unit,20) date, month(1:3)
+    month = fms_time_manager_month_name(date(2))
+    if ( fms_mpp_pe() == fms_mpp_root_pe() ) write (time_stamp_unit,20) date, month(1:3)
 
     call fms_time_manager_get_date (Time_end, date(1), date(2), date(3),  &
                              date(4), date(5), date(6))
-    month = month_name(date(2))
-    if ( mpp_pe() == mpp_root_pe() ) write (time_stamp_unit,20) date, month(1:3)
+    month = fms_time_manager_month_name(date(2))
+    if ( fms_mpp_pe() == fms_mpp_root_pe() ) write (time_stamp_unit,20) date, month(1:3)
 
-    if ( mpp_pe().EQ.mpp_root_pe() ) close (time_stamp_unit)
+    if ( fms_mpp_pe().EQ.fms_mpp_root_pe() ) close (time_stamp_unit)
 
  20 format (6i4,2x,a3)
 
 !-----------------------------------------------------------------------
 !----- compute the time steps ------
 
-    Time_step_atmos = set_time (dt_atmos,0)
-    Time_step_ocean = set_time (dt_ocean,0)
+    Time_step_atmos = fms_time_manager_set_time (dt_atmos,0)
+    Time_step_ocean = fms_time_manager_set_time (dt_ocean,0)
     num_cpld_calls  = Run_length / Time_step_ocean
     num_atmos_calls = Time_step_ocean / Time_step_atmos
 
@@ -465,7 +465,7 @@ contains
 
 !-----------------------------------------------------------------------
 !---- open and close dummy file in restart dir to check if dir exists --
-    if ( mpp_pe().EQ.mpp_root_pe() ) then
+    if ( fms_mpp_pe().EQ.fms_mpp_root_pe() ) then
        open(newunit = ascii_unit, file='RESTART/file', status='replace', form='formatted')
        close(ascii_unit,status="delete")
     endif
@@ -494,7 +494,7 @@ contains
 
 !----- write restart file ------
 
-    if (mpp_pe() == mpp_root_pe())then
+    if (fms_mpp_pe() == fms_mpp_root_pe())then
        open(newunit = restart_unit, file='RESTART/coupler.res', status='replace', form='formatted')
        write(restart_unit, '(i6,8x,a)' )calendar_type, &
             '(Calendar: no_calendar=0, thirty_day_months=1, julian=2, gregorian=3, noleap=4)'
@@ -512,7 +512,7 @@ contains
     call  land_model_end (Atmos_land_boundary, Land)
     call   ice_model_end (Ice)
 
-    call fms_diag_manager_diag_manager_end (Time_atmos)
+    call fms_diag_end (Time_atmos)
 
     call  fms_io_exit
 
@@ -551,8 +551,8 @@ contains
     do i = 1,n_atm_tr
        call fms_tracer_manager_get_tracer_names( MODEL_ATMOS, i, tr_name )
        tr_table(n)%atm = i
-       tr_table(n)%ice = get_tracer_index ( MODEL_ICE,  tr_name )
-       tr_table(n)%lnd = get_tracer_index ( MODEL_LAND, tr_name )
+       tr_table(n)%ice = fms_tracer_manager_get_tracer_index ( MODEL_ICE,  tr_name )
+       tr_table(n)%lnd = fms_tracer_manager_get_tracer_index ( MODEL_LAND, tr_name )
       if (tr_table(n)%ice/=NO_TRACER .or. tr_table(n)%lnd/=NO_TRACER) n = n+1
     enddo
     n_exch_tr = n-1
@@ -561,27 +561,27 @@ contains
 101 FORMAT("CHECKSUM::",A16,a,'%',a," = ",Z20)
 
 
-    outunit = stdout()
+    outunit = fms_mpp_stdout()
     write(outunit,*) 'BEGIN CHECKSUM(Atm):: ', id, timestep
-    write(outunit,100) 'atm%t_bot', mpp_chksum(atm%t_bot)
-    write(outunit,100) 'atm%z_bot', mpp_chksum(atm%z_bot)
-    write(outunit,100) 'atm%p_bot', mpp_chksum(atm%p_bot)
-    write(outunit,100) 'atm%u_bot', mpp_chksum(atm%u_bot)
-    write(outunit,100) 'atm%v_bot', mpp_chksum(atm%v_bot)
-    write(outunit,100) 'atm%p_surf', mpp_chksum(atm%p_surf)
-    write(outunit,100) 'atm%gust', mpp_chksum(atm%gust)
+    write(outunit,100) 'atm%t_bot', fms_mpp_chksum(atm%t_bot)
+    write(outunit,100) 'atm%z_bot', fms_mpp_chksum(atm%z_bot)
+    write(outunit,100) 'atm%p_bot', fms_mpp_chksum(atm%p_bot)
+    write(outunit,100) 'atm%u_bot', fms_mpp_chksum(atm%u_bot)
+    write(outunit,100) 'atm%v_bot', fms_mpp_chksum(atm%v_bot)
+    write(outunit,100) 'atm%p_surf', fms_mpp_chksum(atm%p_surf)
+    write(outunit,100) 'atm%gust', fms_mpp_chksum(atm%gust)
     do tr = 1,n_exch_tr
        n = tr_table(tr)%atm
       if (n /= NO_TRACER) then
           call fms_tracer_manager_get_tracer_names( MODEL_ATMOS, tr_table(tr)%atm, tr_name )
-          write(outunit,100) 'atm%'//trim(tr_name), mpp_chksum(Atm%tr_bot(:,:,n))
+          write(outunit,100) 'atm%'//trim(tr_name), fms_mpp_chksum(Atm%tr_bot(:,:,n))
        endif
     enddo
 
-    write(outunit,100) 'ice%t_surf', mpp_chksum(ice%t_surf)
-    write(outunit,100) 'ice%rough_mom', mpp_chksum(ice%rough_mom)
-    write(outunit,100) 'ice%rough_heat', mpp_chksum(ice%rough_heat)
-    write(outunit,100) 'ice%rough_moist', mpp_chksum(ice%rough_moist)
+    write(outunit,100) 'ice%t_surf', fms_mpp_chksum(ice%t_surf)
+    write(outunit,100) 'ice%rough_mom', fms_mpp_chksum(ice%rough_mom)
+    write(outunit,100) 'ice%rough_heat', fms_mpp_chksum(ice%rough_heat)
+    write(outunit,100) 'ice%rough_moist', fms_mpp_chksum(ice%rough_moist)
     write(outunit,*) 'STOP CHECKSUM(Atm):: ', id, timestep
 
     deallocate(tr_table)

--- a/simple/flux_exchange.F90
+++ b/simple/flux_exchange.F90
@@ -140,7 +140,7 @@ contains
  subroutine sfc_boundary_layer ( dt, Time, Atm, Land, Ice, Boundary )
 
  real,                   intent(in)  :: dt  !< Time step
- type       (time_type), intent(in)  :: Time !< Current time
+ type       (FmsTime_type), intent(in)  :: Time !< Current time
  type (atmos_data_type), intent(in)  :: Atm  !< A derived data type to specify atmospheric boundary data
  type(land_data_type),  intent(inout)  :: Land !< A derived data type to specify land boundary data
  type(ice_data_type),   intent(inout)  :: Ice !< A derived data type to specify ice boundary data
@@ -286,37 +286,37 @@ real :: zrefm, zrefh
 !-------------------- diagnostics section ------------------------------
 
  if (first_static) then
-   if ( id_land_mask   > 0 ) used = send_data ( id_land_mask,   Boundary%land_frac, Time )
+   if ( id_land_mask   > 0 ) used = fms_diag_send_data ( id_land_mask,   Boundary%land_frac, Time )
    ! near-surface heights
-   if ( id_height2m  > 0) used = send_data ( id_height2m, z_ref_heat, Time )
-   if ( id_height10m > 0) used = send_data ( id_height10m, z_ref_mom, Time )
+   if ( id_height2m  > 0) used = fms_diag_send_data ( id_height2m, z_ref_heat, Time )
+   if ( id_height10m > 0) used = fms_diag_send_data ( id_height10m, z_ref_mom, Time )
 
    first_static = .false.
  endif
-   if ( id_wind        > 0 ) used = send_data ( id_wind,        wind,         Time )
-   if ( id_drag_moist  > 0 ) used = send_data ( id_drag_moist,  cd_q,         Time )
-   if ( id_drag_heat   > 0 ) used = send_data ( id_drag_heat,   cd_t,         Time )
-   if ( id_drag_mom    > 0 ) used = send_data ( id_drag_mom,    cd_m,         Time )
-   if ( id_rough_moist > 0 ) used = send_data ( id_rough_moist, rough_moist,  Time )
-   if ( id_rough_heat  > 0 ) used = send_data ( id_rough_heat,  rough_heat,   Time )
-   if ( id_rough_mom   > 0 ) used = send_data ( id_rough_mom,   rough_mom,    Time )
-   if ( id_u_star      > 0 ) used = send_data ( id_u_star,      u_star,       Time )
-   if ( id_b_star      > 0 ) used = send_data ( id_b_star,      b_star,       Time )
-   if ( id_q_star      > 0 ) used = send_data ( id_q_star,      q_star,       Time )
-   if ( id_t_atm       > 0 ) used = send_data ( id_t_atm,       Atm%t_bot,    Time )
-   if ( id_u_atm       > 0 ) used = send_data ( id_u_atm,       Atm%u_bot,    Time )
-   if ( id_v_atm       > 0 ) used = send_data ( id_v_atm,       Atm%v_bot,    Time )
-   if ( id_q_atm       > 0 ) used = send_data ( id_q_atm,       Atm%tr_bot(:,:,isphum),    Time )
-   if ( id_p_atm       > 0 ) used = send_data ( id_p_atm,       Atm%p_bot,    Time )
-   if ( id_z_atm       > 0 ) used = send_data ( id_z_atm,       Atm%z_bot,    Time )
-   if ( id_gust        > 0 ) used = send_data ( id_gust,        Atm%gust,     Time )
-   if ( id_u_flux      > 0 ) used = send_data ( id_u_flux,      flux_u,       Time )
-   if ( id_v_flux      > 0 ) used = send_data ( id_v_flux,      flux_v,       Time )
-   if ( id_albedo      > 0 ) used = send_data ( id_albedo,      albedo,       Time )
-   if ( id_albedo_vis_dir > 0 ) used = send_data ( id_albedo_vis_dir, albedo_vis_dir, Time )
-   if ( id_albedo_nir_dir > 0 ) used = send_data ( id_albedo_nir_dir, albedo_nir_dir, Time )
-   if ( id_albedo_vis_dif > 0 ) used = send_data ( id_albedo_vis_dif, albedo_vis_dif, Time )
-   if ( id_albedo_nir_dif > 0 ) used = send_data ( id_albedo_nir_dif, albedo_nir_dif, Time )
+   if ( id_wind        > 0 ) used = fms_diag_send_data ( id_wind,        wind,         Time )
+   if ( id_drag_moist  > 0 ) used = fms_diag_send_data ( id_drag_moist,  cd_q,         Time )
+   if ( id_drag_heat   > 0 ) used = fms_diag_send_data ( id_drag_heat,   cd_t,         Time )
+   if ( id_drag_mom    > 0 ) used = fms_diag_send_data ( id_drag_mom,    cd_m,         Time )
+   if ( id_rough_moist > 0 ) used = fms_diag_send_data ( id_rough_moist, rough_moist,  Time )
+   if ( id_rough_heat  > 0 ) used = fms_diag_send_data ( id_rough_heat,  rough_heat,   Time )
+   if ( id_rough_mom   > 0 ) used = fms_diag_send_data ( id_rough_mom,   rough_mom,    Time )
+   if ( id_u_star      > 0 ) used = fms_diag_send_data ( id_u_star,      u_star,       Time )
+   if ( id_b_star      > 0 ) used = fms_diag_send_data ( id_b_star,      b_star,       Time )
+   if ( id_q_star      > 0 ) used = fms_diag_send_data ( id_q_star,      q_star,       Time )
+   if ( id_t_atm       > 0 ) used = fms_diag_send_data ( id_t_atm,       Atm%t_bot,    Time )
+   if ( id_u_atm       > 0 ) used = fms_diag_send_data ( id_u_atm,       Atm%u_bot,    Time )
+   if ( id_v_atm       > 0 ) used = fms_diag_send_data ( id_v_atm,       Atm%v_bot,    Time )
+   if ( id_q_atm       > 0 ) used = fms_diag_send_data ( id_q_atm,       Atm%tr_bot(:,:,isphum),    Time )
+   if ( id_p_atm       > 0 ) used = fms_diag_send_data ( id_p_atm,       Atm%p_bot,    Time )
+   if ( id_z_atm       > 0 ) used = fms_diag_send_data ( id_z_atm,       Atm%z_bot,    Time )
+   if ( id_gust        > 0 ) used = fms_diag_send_data ( id_gust,        Atm%gust,     Time )
+   if ( id_u_flux      > 0 ) used = fms_diag_send_data ( id_u_flux,      flux_u,       Time )
+   if ( id_v_flux      > 0 ) used = fms_diag_send_data ( id_v_flux,      flux_v,       Time )
+   if ( id_albedo      > 0 ) used = fms_diag_send_data ( id_albedo,      albedo,       Time )
+   if ( id_albedo_vis_dir > 0 ) used = fms_diag_send_data ( id_albedo_vis_dir, albedo_vis_dir, Time )
+   if ( id_albedo_nir_dir > 0 ) used = fms_diag_send_data ( id_albedo_nir_dir, albedo_nir_dir, Time )
+   if ( id_albedo_vis_dif > 0 ) used = fms_diag_send_data ( id_albedo_vis_dif, albedo_vis_dif, Time )
+   if ( id_albedo_nir_dif > 0 ) used = fms_diag_send_data ( id_albedo_nir_dif, albedo_nir_dif, Time )
 
 !---- ice fraction ----
    if ( id_ice_mask > 0 ) then
@@ -325,7 +325,7 @@ real :: zrefm, zrefh
        elsewhere
           ref = 0.0
        endwhere
-       used = send_data ( id_ice_mask, ref, Time )
+       used = fms_diag_send_data ( id_ice_mask, ref, Time )
    endif
 
  ! diagnostics for fields at reference level
@@ -347,8 +347,8 @@ real :: zrefm, zrefh
      !---- reference relative humidity ----
       if ( id_rh_ref > 0 .or.  id_q_ref > 0 .or. id_hurs > 0 .or. id_huss > 0) then
          ref   = q_surf + (Atm%tr_bot(:,:,isphum)-q_surf) * del_q
-         if (id_q_ref > 0) used = send_data ( id_q_ref, ref, Time )
-         if (id_huss  > 0) used = send_data (id_huss,ref,Time)
+         if (id_q_ref > 0) used = fms_diag_send_data ( id_q_ref, ref, Time )
+         if (id_huss  > 0) used = fms_diag_send_data (id_huss,ref,Time)
 
          t_ref = t_ca + (Atm%t_bot-t_ca) * del_h
          !call escomp (t_ref, qs_ref)
@@ -360,55 +360,55 @@ real :: zrefm, zrefh
          ref    = 100.*ref/qs_ref
          ref2   = 100.*ref/qs_ref_cmip
 
-         if (id_rh_ref > 0) used = send_data ( id_rh_ref, ref, Time )
-         if (id_hurs   > 0) used = send_data ( id_hurs, ref2, Time )
+         if (id_rh_ref > 0) used = fms_diag_send_data ( id_rh_ref, ref, Time )
+         if (id_hurs   > 0) used = fms_diag_send_data ( id_hurs, ref2, Time )
       endif
 
      !---- reference temperature ----
       if ( id_t_ref > 0 ) then
          ref = t_ca + (Atm%t_bot-t_ca) * del_h
-         used = send_data ( id_t_ref, ref, Time )
+         used = fms_diag_send_data ( id_t_ref, ref, Time )
       endif
 
      !---- reference u comp ----
       if ( id_u_ref > 0 .or. id_uas > 0) then
          ref = u_surf + (Atm%u_bot-u_surf) * del_m
-         used = send_data ( id_u_ref, ref, Time )
+         used = fms_diag_send_data ( id_u_ref, ref, Time )
       endif
-      if ( id_uas > 0 ) used = send_data ( id_uas, ref, Time )
+      if ( id_uas > 0 ) used = fms_diag_send_data ( id_uas, ref, Time )
 
      !---- reference v comp ----
       if ( id_v_ref > 0 .or. id_vas > 0) then
          ref = v_surf + (Atm%v_bot-v_surf) * del_m
-         used = send_data ( id_v_ref, ref, Time )
+         used = fms_diag_send_data ( id_v_ref, ref, Time )
       endif
-      if ( id_vas > 0 ) used = send_data ( id_vas, ref, Time )
+      if ( id_vas > 0 ) used = fms_diag_send_data ( id_vas, ref, Time )
 
       !    ------- reference-level absolute wind -----------
       if ( id_sfcWind > 0 ) then
               ref = sqrt((u_surf + (Atm%u_bot-u_surf) * del_m)**2 &
               +(v_surf + (Atm%v_bot-v_surf) * del_m)**2)
-         if ( id_sfcWind  > 0 ) used = send_data ( id_sfcWind, ref , Time )
+         if ( id_sfcWind  > 0 ) used = fms_diag_send_data ( id_sfcWind, ref , Time )
       endif
 
 
      !---- interp factors ----
-      if ( id_del_h > 0 )  used = send_data ( id_del_h, del_h, Time )
-      if ( id_del_m > 0 )  used = send_data ( id_del_m, del_m, Time )
-      if ( id_del_q > 0 )  used = send_data ( id_del_q, del_q, Time )
+      if ( id_del_h > 0 )  used = fms_diag_send_data ( id_del_h, del_h, Time )
+      if ( id_del_m > 0 )  used = fms_diag_send_data ( id_del_m, del_m, Time )
+      if ( id_del_q > 0 )  used = fms_diag_send_data ( id_del_q, del_q, Time )
 
    endif
 
   ! topographic roughness scale
    if (id_rough_scale > 0) then
      ref = (log(Atm%z_bot/rough_mom+1)/log(Atm%z_bot/rough_scale+1))**2
-     used = send_data(id_rough_scale, ref, Time)
+     used = fms_diag_send_data(id_rough_scale, ref, Time)
   endif
 
 ! lgs line below is from atm_land_ice_flux_exchange.F90  what should diag_atm be?
-!   if ( id_tas         > 0 ) used = send_data ( id_tas, diag_atm, Time )
-   if ( id_tas > 0 ) used = send_data ( id_tas, t_ref, Time )
-   if ( id_psl > 0 ) used = send_data ( id_psl, Atm%slp , Time )
+!   if ( id_tas         > 0 ) used = fms_diag_send_data ( id_tas, diag_atm, Time )
+   if ( id_tas > 0 ) used = fms_diag_send_data ( id_tas, t_ref, Time )
+   if ( id_psl > 0 ) used = fms_diag_send_data ( id_psl, Atm%slp , Time )
 
 
 !=======================================================================
@@ -420,7 +420,7 @@ real :: zrefm, zrefh
 subroutine flux_down_from_atmos (Time, Atm, Land, Ice,  &
                          Atmos_boundary, Land_boundary, Ice_boundary )
 
-type       (time_type), intent(in)  :: Time
+type       (FmsTime_type), intent(in)  :: Time
 type (atmos_data_type), intent(in)  :: Atm
 type  (land_data_type), intent(in)  :: Land
 type   (ice_data_type), intent(in)  :: Ice
@@ -543,10 +543,10 @@ real, dimension(is:ie,js:je) :: gamma, dtmass, delta_t, delta_q, &
 !-----------------------------------------------------------------------
 !-------------------- diagnostics section ------------------------------
 
-if ( id_u_flux > 0 ) used = send_data ( id_u_flux, Atmos_boundary%u_flux, Time )
-if ( id_tauu > 0 )   used = send_data ( id_tauu,  -Atmos_boundary%u_flux, Time )
-if ( id_v_flux > 0 ) used = send_data ( id_v_flux, Atmos_boundary%v_flux, Time )
-if ( id_tauv > 0 )   used = send_data ( id_tauv,  -Atmos_boundary%v_flux, Time )
+if ( id_u_flux > 0 ) used = fms_diag_send_data ( id_u_flux, Atmos_boundary%u_flux, Time )
+if ( id_tauu > 0 )   used = fms_diag_send_data ( id_tauu,  -Atmos_boundary%u_flux, Time )
+if ( id_v_flux > 0 ) used = fms_diag_send_data ( id_v_flux, Atmos_boundary%v_flux, Time )
+if ( id_tauv > 0 )   used = fms_diag_send_data ( id_tauv,  -Atmos_boundary%v_flux, Time )
 
 !-----------------------------------------------------------------------
 
@@ -556,7 +556,7 @@ end subroutine flux_down_from_atmos
 
 subroutine flux_up_to_atmos (Time, Land, Ice, Boundary )
 
- type(time_type),      intent(in)  :: Time
+ type(FmsTime_type),      intent(in)  :: Time
  type(land_data_type), intent(inout)  :: Land
  type(ice_data_type),  intent(inout)  :: Ice
  type(land_ice_atmos_boundary_type), intent(inout) :: Boundary
@@ -604,24 +604,24 @@ subroutine flux_up_to_atmos (Time, Land, Ice, Boundary )
      Boundary%dt_tr(:,:,isphum) = f_q_delt_n  + dt_t_surf*e_q_n
   endwhere
 
-!print *, 'PE,dt_t(L)(mn,mx)=',mpp_pe(),minval(Boundary%dt_t,mask=Land%mask(:,:,1)),maxval(Boundary%dt_t,mask=Land%mask(:,:,1))
-!print *, 'PE,dt_q(L)(mn,mx)=',mpp_pe(),minval(Boundary%dt_q,mask=Land%mask(:,:,1)),maxval(Boundary%dt_q,mask=Land%mask(:,:,1))
-!print *, 'PE,dt_t(I)(mn,mx)=',mpp_pe(),minval(Boundary%dt_t,mask=Ice%mask),maxval(Boundary%dt_t,mask=Ice%mask)
-!print *, 'PE,dt_q(I)(mn,mx)=',mpp_pe(),minval(Boundary%dt_q,mask=Ice%mask),maxval(Boundary%dt_q,mask=Ice%mask)
+!print *, 'PE,dt_t(L)(mn,mx)=',fms_mpp_pe(),minval(Boundary%dt_t,mask=Land%mask(:,:,1)),maxval(Boundary%dt_t,mask=Land%mask(:,:,1))
+!print *, 'PE,dt_q(L)(mn,mx)=',fms_mpp_pe(),minval(Boundary%dt_q,mask=Land%mask(:,:,1)),maxval(Boundary%dt_q,mask=Land%mask(:,:,1))
+!print *, 'PE,dt_t(I)(mn,mx)=',fms_mpp_pe(),minval(Boundary%dt_t,mask=Ice%mask),maxval(Boundary%dt_t,mask=Ice%mask)
+!print *, 'PE,dt_q(I)(mn,mx)=',fms_mpp_pe(),minval(Boundary%dt_q,mask=Ice%mask),maxval(Boundary%dt_q,mask=Ice%mask)
 
 !=======================================================================
 !-------------------- diagnostics section ------------------------------
 
-   if ( id_t_surf > 0 ) used = send_data ( id_t_surf, t_surf_new, Time )
-   if ( id_t_ca   > 0 ) used = send_data ( id_t_ca,   t_ca_new,   Time )
-   if ( id_q_surf > 0 ) used = send_data ( id_q_surf, q_surf_new, Time )
-   if ( id_t_flux > 0 ) used = send_data ( id_t_flux, flux_t,     Time )
-   if ( id_r_flux > 0 ) used = send_data ( id_r_flux, flux_lw,    Time )
-   if ( id_q_flux > 0 ) used = send_data ( id_q_flux, flux_q,     Time )
-   if ( id_evspsbl> 0 ) used = send_data ( id_evspsbl, flux_q,    Time )
-   if ( id_hfls   > 0 ) used = send_data ( id_hfls,   HLV*flux_q, Time )
-   if ( id_hfss   > 0 ) used = send_data ( id_hfss,   flux_t,     Time )
-   if ( id_ts     > 0 ) used = send_data ( id_ts,     t_surf_new, Time )
+   if ( id_t_surf > 0 ) used = fms_diag_send_data ( id_t_surf, t_surf_new, Time )
+   if ( id_t_ca   > 0 ) used = fms_diag_send_data ( id_t_ca,   t_ca_new,   Time )
+   if ( id_q_surf > 0 ) used = fms_diag_send_data ( id_q_surf, q_surf_new, Time )
+   if ( id_t_flux > 0 ) used = fms_diag_send_data ( id_t_flux, flux_t,     Time )
+   if ( id_r_flux > 0 ) used = fms_diag_send_data ( id_r_flux, flux_lw,    Time )
+   if ( id_q_flux > 0 ) used = fms_diag_send_data ( id_q_flux, flux_q,     Time )
+   if ( id_evspsbl> 0 ) used = fms_diag_send_data ( id_evspsbl, flux_q,    Time )
+   if ( id_hfls   > 0 ) used = fms_diag_send_data ( id_hfls,   HLV*flux_q, Time )
+   if ( id_hfss   > 0 ) used = fms_diag_send_data ( id_hfss,   flux_t,     Time )
+   if ( id_ts     > 0 ) used = fms_diag_send_data ( id_ts,     t_surf_new, Time )
 
    call fms_sum_diag_integral_field ('evap', flux_q*86400.)
 
@@ -647,7 +647,7 @@ subroutine flux_up_to_atmos (Time, Land, Ice, Boundary )
                                  atmos_ice_boundary,     &
                                  land_ice_atmos_boundary )
 
- type       (time_type), intent(in)  :: Time
+ type       (FmsTime_type), intent(in)  :: Time
  type (atmos_data_type), intent(in)  :: Atm
  type  (land_data_type), intent(in)  :: Land
  type   (ice_data_type), intent(in)  :: Ice
@@ -673,17 +673,17 @@ subroutine flux_up_to_atmos (Time, Land, Ice, Boundary )
 !--------- write version number and namelist ------------------
 
    call fms_write_version_number (version, tag)
-   if ( mpp_pe() == mpp_root_pe() ) write (stdlog(), nml=flux_exchange_nml)
+   if ( fms_mpp_pe() == fms_mpp_root_pe() ) write (fms_mpp_stdlog(), nml=flux_exchange_nml)
 
 
    call fms_diag_integral_field_init ('evap', 'f6.3')
-   call fms_diag_field_init ( Time, Atm%axes(1:2) )
+   call diag_field_init ( Time, Atm%axes(1:2) )
 
 !----- find out number of atmospheric prognostic tracers and index of specific
 !      humidity in the tracer table
    call fms_tracer_manager_get_number_tracers (MODEL_ATMOS, num_tracers=n_atm_tr_tot, &
                             num_prog=n_atm_tr)
-   isphum = get_tracer_index( MODEL_ATMOS, 'sphum' )
+   isphum = fms_tracer_manager_get_tracer_index( MODEL_ATMOS, 'sphum' )
    if (isphum==NO_TRACER) &
       call error_mesg('flux_exchange_mod', 'Cannot find water vapor in ATM tracer table', FATAL)
 !-----------------------------------------------------------------------
@@ -836,7 +836,7 @@ subroutine flux_up_to_atmos (Time, Land, Ice, Boundary )
 
  integer :: ierr, io
 
-   read (input_nml_file, nml=flux_exchange_nml, iostat=io)
+   read (fms_mpp_input_nml_file, nml=flux_exchange_nml, iostat=io)
    ierr = check_nml_error(io, 'flux_exchange_nml')
 
    do_read_nml = .false.
@@ -847,7 +847,7 @@ subroutine flux_up_to_atmos (Time, Land, Ice, Boundary )
 
 subroutine diag_field_init ( Time, atmos_axes )
 
-  type(time_type), intent(in) :: Time
+  type(FmsTime_type), intent(in) :: Time
   integer,         intent(in) :: atmos_axes(2)
 
   integer :: iref
@@ -887,175 +887,175 @@ subroutine diag_field_init ( Time, atmos_axes )
  !--------- initialize static diagnostic fields --------------------
 
   id_land_mask = &
-       register_static_field ( mod_name, 'land_mask', atmos_axes,  &
+      fms_diag_register_static_field ( mod_name, 'land_mask', atmos_axes,  &
        'fractional amount of land', 'none', &
        range=frange )
 
  !--------- initialize diagnostic fields --------------------
 
   id_ice_mask = &
-       register_diag_field ( mod_name, 'ice_mask', atmos_axes, Time, &
+       fms_diag_register_diag_field ( mod_name, 'ice_mask', atmos_axes, Time, &
        'fractional amount of sea ice', 'none',  &
        range=frange )
 
    id_wind = &
-   register_diag_field ( mod_name, 'wind', atmos_axes, Time, &
+   fms_diag_register_diag_field ( mod_name, 'wind', atmos_axes, Time, &
                         'wind speed for flux calculations', 'm/s', &
                          range=(/0.,vrange(2)/) )
 
    id_drag_moist = &
-   register_diag_field ( mod_name, 'drag_moist', atmos_axes, Time, &
+   fms_diag_register_diag_field ( mod_name, 'drag_moist', atmos_axes, Time, &
                         'drag coeff for moisture',    'none'     )
 
    id_drag_heat  = &
-   register_diag_field ( mod_name, 'drag_heat', atmos_axes, Time, &
+   fms_diag_register_diag_field ( mod_name, 'drag_heat', atmos_axes, Time, &
                         'drag coeff for heat',    'none'     )
 
    id_drag_mom   = &
-   register_diag_field ( mod_name, 'drag_mom',  atmos_axes, Time, &
+   fms_diag_register_diag_field ( mod_name, 'drag_mom',  atmos_axes, Time, &
                         'drag coeff for momentum',     'none'     )
 
    id_rough_moist = &
-   register_diag_field ( mod_name, 'rough_moist', atmos_axes, Time, &
+   fms_diag_register_diag_field ( mod_name, 'rough_moist', atmos_axes, Time, &
                         'surface roughness for moisture',  'm'  )
 
    id_rough_heat = &
-   register_diag_field ( mod_name, 'rough_heat', atmos_axes, Time, &
+   fms_diag_register_diag_field ( mod_name, 'rough_heat', atmos_axes, Time, &
                         'surface roughness for heat',  'm'  )
 
    id_rough_mom  = &
-   register_diag_field ( mod_name, 'rough_mom',  atmos_axes, Time, &
+   fms_diag_register_diag_field ( mod_name, 'rough_mom',  atmos_axes, Time, &
                         'surface roughness for momentum',  'm'  )
 
    id_u_star     = &
-   register_diag_field ( mod_name, 'u_star',     atmos_axes, Time, &
+   fms_diag_register_diag_field ( mod_name, 'u_star',     atmos_axes, Time, &
                         'friction velocity',   'm/s'   )
 
    id_b_star     = &
-   register_diag_field ( mod_name, 'b_star',     atmos_axes, Time, &
+   fms_diag_register_diag_field ( mod_name, 'b_star',     atmos_axes, Time, &
                         'buoyancy scale',      'm/s2'   )
 
   id_q_star     = &
-       register_diag_field ( mod_name, 'q_star',     atmos_axes, Time, &
+       fms_diag_register_diag_field ( mod_name, 'q_star',     atmos_axes, Time, &
        'moisture scale',      'kg water/kg air'   )
 
    id_u_flux     = &
-   register_diag_field ( mod_name, 'tau_x',      atmos_axes, Time, &
+   fms_diag_register_diag_field ( mod_name, 'tau_x',      atmos_axes, Time, &
                         'zonal wind stress',     'pa'   )
 
    id_v_flux     = &
-   register_diag_field ( mod_name, 'tau_y',      atmos_axes, Time, &
+   fms_diag_register_diag_field ( mod_name, 'tau_y',      atmos_axes, Time, &
                         'meridional wind stress',     'pa'   )
 
    id_t_surf     = &
-   register_diag_field ( mod_name, 't_surf',     atmos_axes, Time, &
+   fms_diag_register_diag_field ( mod_name, 't_surf',     atmos_axes, Time, &
                         'surface temperature',    'deg_k', &
                         range=trange    )
 
   id_t_ca       = &
-       register_diag_field ( mod_name, 't_ca',     atmos_axes, Time, &
+       fms_diag_register_diag_field ( mod_name, 't_ca',     atmos_axes, Time, &
        'canopy air temperature',    'deg_k', &
        range=trange    )
 
   id_q_atm     = &
-       register_diag_field ( mod_name, 'q_atm',     atmos_axes, Time, &
+       fms_diag_register_diag_field ( mod_name, 'q_atm',     atmos_axes, Time, &
        'specific humidity at btm level',    'kg/kg')
 
   id_q_surf     = &
-       register_diag_field ( mod_name, 'q_surf',     atmos_axes, Time, &
+       fms_diag_register_diag_field ( mod_name, 'q_surf',     atmos_axes, Time, &
        'surface specific humidity',    'kg/kg')
 
   id_z_atm      = &
-       register_diag_field ( mod_name, 'z_atm',     atmos_axes, Time, &
+       fms_diag_register_diag_field ( mod_name, 'z_atm',     atmos_axes, Time, &
        'height of btm level',    'm')
 
   id_p_atm      = &
-       register_diag_field ( mod_name, 'p_atm',     atmos_axes, Time, &
+       fms_diag_register_diag_field ( mod_name, 'p_atm',     atmos_axes, Time, &
        'pressure at btm level',    'pa')
 
   id_gust       = &
-       register_diag_field ( mod_name, 'gust',     atmos_axes, Time, &
+       fms_diag_register_diag_field ( mod_name, 'gust',     atmos_axes, Time, &
        'gust scale',    'm/s')
 
    id_t_flux     = &
-   register_diag_field ( mod_name, 'shflx',      atmos_axes, Time, &
+   fms_diag_register_diag_field ( mod_name, 'shflx',      atmos_axes, Time, &
                         'sensible heat flux',     'w/m2'    )
 
    id_q_flux     = &
-   register_diag_field ( mod_name, 'evap',       atmos_axes, Time, &
+   fms_diag_register_diag_field ( mod_name, 'evap',       atmos_axes, Time, &
                         'evaporation rate',        'kg/m2/s'  )
 
    id_r_flux     = &
-   register_diag_field ( mod_name, 'lwflx',      atmos_axes, Time, &
+   fms_diag_register_diag_field ( mod_name, 'lwflx',      atmos_axes, Time, &
                         'net (down-up) longwave flux',   'w/m2'    )
 
    id_t_atm      = &
-   register_diag_field ( mod_name, 't_atm',      atmos_axes, Time, &
+   fms_diag_register_diag_field ( mod_name, 't_atm',      atmos_axes, Time, &
                         'temperature at btm level',    'deg_k', &
                         range=trange     )
 
    id_u_atm      = &
-   register_diag_field ( mod_name, 'u_atm',      atmos_axes, Time, &
+   fms_diag_register_diag_field ( mod_name, 'u_atm',      atmos_axes, Time, &
                         'u wind component at btm level',  'm/s', &
                         range=vrange    )
 
    id_v_atm      = &
-   register_diag_field ( mod_name, 'v_atm',      atmos_axes, Time, &
+   fms_diag_register_diag_field ( mod_name, 'v_atm',      atmos_axes, Time, &
                         'v wind component at btm level',  'm/s', &
                         range=vrange    )
 
    id_t_ref      = &
-   register_diag_field ( mod_name, 't_ref',      atmos_axes, Time, &
+   fms_diag_register_diag_field ( mod_name, 't_ref',      atmos_axes, Time, &
                         'temperature at '//label_zh, 'deg_k' , &
                         range=trange      )
 
    id_rh_ref     = &
-   register_diag_field ( mod_name, 'rh_ref',     atmos_axes, Time,   &
+   fms_diag_register_diag_field ( mod_name, 'rh_ref',     atmos_axes, Time,   &
                         'relative humidity at '//label_zh, 'percent' )
 
    id_u_ref      = &
-   register_diag_field ( mod_name, 'u_ref',      atmos_axes, Time, &
+   fms_diag_register_diag_field ( mod_name, 'u_ref',      atmos_axes, Time, &
                         'zonal wind component at '//label_zm,  'm/s', &
                         range=vrange )
 
    id_v_ref      = &
-   register_diag_field ( mod_name, 'v_ref',      atmos_axes, Time,     &
+   fms_diag_register_diag_field ( mod_name, 'v_ref',      atmos_axes, Time,     &
                       'meridional wind component at '//label_zm, 'm/s', &
                         range=vrange )
    id_q_ref = &
-       register_diag_field ( mod_name, 'q_ref', atmos_axes, Time,     &
+       fms_diag_register_diag_field ( mod_name, 'q_ref', atmos_axes, Time,     &
        'specific humidity at '//trim(label_zh), 'kg/kg', missing_value=-1.0)
 
    id_del_h      = &
-   register_diag_field ( mod_name, 'del_h',      atmos_axes, Time,  &
+   fms_diag_register_diag_field ( mod_name, 'del_h',      atmos_axes, Time,  &
                         'ref height interp factor for heat', 'none' )
    id_del_m      = &
-   register_diag_field ( mod_name, 'del_m',      atmos_axes, Time,     &
+   fms_diag_register_diag_field ( mod_name, 'del_m',      atmos_axes, Time,     &
                         'ref height interp factor for momentum','none' )
    id_del_q      = &
-   register_diag_field ( mod_name, 'del_q',      atmos_axes, Time,     &
+   fms_diag_register_diag_field ( mod_name, 'del_q',      atmos_axes, Time,     &
                         'ref height interp factor for moisture','none' )
    id_albedo      = &
-   register_diag_field ( mod_name, 'albedo',      atmos_axes, Time,     &
+   fms_diag_register_diag_field ( mod_name, 'albedo',      atmos_axes, Time,     &
                         'surface albedo','none' )
    id_albedo_vis_dir = &
-   register_diag_field ( mod_name, 'albedo_vis_dir', atmos_axes, Time,     &
+   fms_diag_register_diag_field ( mod_name, 'albedo_vis_dir', atmos_axes, Time,     &
                         'VIS direct surface albedo','none' )
    id_albedo_nir_dir = &
-   register_diag_field ( mod_name, 'albedo_nir_dir', atmos_axes, Time,     &
+   fms_diag_register_diag_field ( mod_name, 'albedo_nir_dir', atmos_axes, Time,     &
                         'NIR direct surface albedo','none' )
    id_albedo_vis_dif = &
-   register_diag_field ( mod_name, 'albedo_vis_dif', atmos_axes, Time,     &
+   fms_diag_register_diag_field ( mod_name, 'albedo_vis_dif', atmos_axes, Time,     &
                         'VIS diffuse surface albedo','none' )
    id_albedo_nir_dif = &
-   register_diag_field ( mod_name, 'albedo_nir_dif', atmos_axes, Time,     &
+   fms_diag_register_diag_field ( mod_name, 'albedo_nir_dif', atmos_axes, Time,     &
                         'NIR diffuse surface albedo','none' )
 
     !--------------------------------------------------------------------
     !    retrieve the diag_manager id for the area diagnostic,
     !    needed for cmorizing various diagnostics.
     !--------------------------------------------------------------------
-    area_id = get_diag_field_id ('dynamics', 'area')
+    area_id = fms_diag_get_field_id ('dynamics', 'area')
     if (area_id .eq. DIAG_FIELD_NOT_FOUND) call error_mesg &
          ('diag_field_init in atm_land_ice_flux_exchange_mod', &
          'diagnostic field "dynamics", "area" is not in the diag_table', NOTE)
@@ -1067,7 +1067,7 @@ subroutine diag_field_init ( Time, atmos_axes )
                             'Near-Surface Air Temperature', 'K' , &
                              standard_name='air_temperature' )
     if ( id_tas > 0 .and. id_height2m > 0) &
-       call fms_diag_manager_diag_field_add_attribute( id_tas, 'coordinates', 'height2m' )
+       call fms_diag_field_add_attribute( id_tas, 'coordinates', 'height2m' )
 ! in diag table include height2m wherever tas is included
 
     id_evspsbl = register_cmip_diag_field_2d ( mod_name, 'evspsbl', Time, &
@@ -1078,31 +1078,31 @@ subroutine diag_field_init ( Time, atmos_axes )
                            'Eastward Near-Surface Wind', 'm s-1', &
                             standard_name='eastward_wind' )
     if ( id_uas > 0 .and. id_height10m > 0) &
-       call fms_diag_manager_diag_field_add_attribute( id_uas, 'coordinates', 'height10m' )
+       call fms_diag_field_add_attribute( id_uas, 'coordinates', 'height10m' )
 
     id_vas = register_cmip_diag_field_2d ( mod_name, 'vas', Time, &
                           'Northward Near-Surface Wind', 'm s-1', &
                            standard_name='northward_wind' )
     if ( id_vas > 0 .and. id_height10m > 0 ) &
-       call fms_diag_manager_diag_field_add_attribute( id_vas, 'coordinates', 'height10m' )
+       call fms_diag_field_add_attribute( id_vas, 'coordinates', 'height10m' )
 
     id_sfcWind = register_cmip_diag_field_2d ( mod_name, 'sfcWind', Time, &
                                       'Near-Surface Wind Speed', 'm s-1', &
                                        standard_name='wind_speed' )
     if ( id_sfcWind > 0 .and. id_height10m > 0 ) &
-       call fms_diag_manager_diag_field_add_attribute( id_sfcWind, 'coordinates', 'height10m' )
+       call fms_diag_field_add_attribute( id_sfcWind, 'coordinates', 'height10m' )
 
     id_huss = register_cmip_diag_field_2d ( mod_name, 'huss', Time, &
                            'Near-Surface Specific Humidity', '1.0', &
                             standard_name='specific_humidity' )
     if ( id_huss > 0 .and. id_height2m > 0 ) &
-       call fms_diag_manager_diag_field_add_attribute( id_huss, 'coordinates', 'height2m' )
+       call fms_diag_field_add_attribute( id_huss, 'coordinates', 'height2m' )
 
     id_hurs = register_cmip_diag_field_2d ( mod_name, 'hurs', Time, &
                              'Near-Surface Relative Humidity', '%', &
                               standard_name='relative_humidity' )
     if ( id_hurs > 0 .and. id_height2m > 0 ) &
-       call fms_diag_manager_diag_field_add_attribute( id_hurs, 'coordinates', 'height2m' )
+       call fms_diag_field_add_attribute( id_hurs, 'coordinates', 'height2m' )
 
     id_ts = register_cmip_diag_field_2d ( mod_name, 'ts', Time, &
                                     'Surface Temperature', 'K', &
@@ -1124,7 +1124,7 @@ subroutine diag_field_init ( Time, atmos_axes )
                         'Surface Upward Latent Heat Flux', 'W m-2', &
                     standard_name='surface_upward_latent_heat_flux' )
     if ( id_hfls > 0 ) &
-       call fms_diag_manager_diag_field_add_attribute( id_hfls, 'comment', 'Lv*evap' )
+       call fms_diag_field_add_attribute( id_hfls, 'comment', 'Lv*evap' )
 
     id_hfss = register_cmip_diag_field_2d ( mod_name, 'hfss', Time, &
                       'Surface Upward Sensible Heat Flux', 'W m-2', &

--- a/simple/ice_model.F90
+++ b/simple/ice_model.F90
@@ -27,8 +27,8 @@ use ocean_albedo_mod, only:  compute_ocean_albedo_new
 use  ocean_rough_mod, only:  compute_ocean_roughness, fixed_ocean_roughness
 
 !! FMS
-use FMS, sst_anom_fms=>sst_anom
-use FMSconstants, only: HLV, HLF, TFREEZE, pi
+use FMS!,              only: fms_amip_interp_sst_anom
+use FMSconstants,     only: HLV, HLF, TFREEZE, pi
 
 implicit none
 private
@@ -100,12 +100,12 @@ namelist /ice_model_nml/ diff, thickness_min, specified_ice_thickness,        &
                          heat_capacity_ocean, temp_ice_freeze, roughness_ice, &
                          ice_method, use_climo_ice, use_annual_ice, temp_ice, &
                          sst_method, use_climo_sst, use_annual_sst, temp_sst, &
-                         interp_method, do_netcdf_restart, sst_anom
+                         interp_method, do_netcdf_restart, fms_amip_interp_sst_anom
 
 !----------------------------------------------------------------
 
 type ice_data_type
-  type(domain2d),pointer                :: Domain
+  type(FmsMppDomain2D),pointer                :: Domain
 
    real,    pointer, dimension(:,:)     :: glon_bnd =>NULL(), &
                                            glat_bnd =>NULL(), &
@@ -132,7 +132,7 @@ type ice_data_type
                                          rough_moist =>NULL(), &
                                          thickness =>NULL()
 
-   type (time_type)                   :: Time_Init, Time,  &
+   type (FmsTime_type)                   :: Time_Init, Time,  &
                                          Time_step_fast,   &
                                          Time_step_slow
 end type ice_data_type
@@ -158,7 +158,7 @@ end type atmos_ice_boundary_type
 !----------------------------------------------------------------
 
 integer :: is, ie, js, je
-type(amip_interp_type), save :: Amip_ice, Amip_sst
+type(FmsAmipInterp_type), save :: Amip_ice, Amip_sst
 logical :: module_is_initialized = .false.
 character(len=64) :: fname = 'INPUT/ice_model.res.nc'
 
@@ -410,10 +410,10 @@ endif
                              Time_step_fast, Time_step_slow, &
                              glon_bnd, glat_bnd, Atmos_domain )
  type(ice_data_type), intent(inout) :: Ice
- type(time_type)    , intent(in)    :: Time_Init, Time, &
+ type(FmsTime_type)    , intent(in)    :: Time_Init, Time, &
                                        Time_step_fast, Time_step_slow
  real               , intent(in)    :: glon_bnd(:,:), glat_bnd(:,:)
- type(domain2d), intent(in), target :: Atmos_domain
+ type(FmsMppDomain2D), intent(in), target :: Atmos_domain
 
 real :: lon0, lond, latd, amp, t_control, dellon, dom_wid, siggy, tempi
  integer :: isg, ieg, jsg, jeg
@@ -428,14 +428,14 @@ real :: lon0, lond, latd, amp, t_control, dellon, dom_wid, siggy, tempi
  endif
 
  !< Read the namelist
- read (input_nml_file, nml=ice_model_nml, iostat=io)
+ read (fms_mpp_input_nml_file, nml=ice_model_nml, iostat=io)
  ierr = check_nml_error(io, 'ice_model_nml')
 
  do_netcdf_restart = .true. !< Always do netcdf!
 
  call fms_write_version_number (version, tagname)
- if ( mpp_pe() == mpp_root_pe() ) then
-    write (stdlog(), nml=ice_model_nml)
+ if ( fms_mpp_pe() == fms_mpp_root_pe() ) then
+    write (fms_mpp_stdlog(), nml=ice_model_nml)
  endif
 
 !---- error checks ----
@@ -492,7 +492,7 @@ real :: lon0, lond, latd, amp, t_control, dellon, dom_wid, siggy, tempi
 ! if (present(Atmos_domain)) then
 !     call mpp_get_layout (Atmos_domain, layout)
 ! else
-!     call mpp_define_layout  ( (/1,nlon,1,nlat/), mpp_npes(), layout )
+!     call mpp_define_layout  ( (/1,nlon,1,nlat/), fms_mpp_npes(), layout )
 ! endif
 
 ! call mpp_define_domains ( (/1,nlon,1,nlat/), layout, Ice%Domain, &
@@ -502,7 +502,7 @@ real :: lon0, lond, latd, amp, t_control, dellon, dom_wid, siggy, tempi
 
 !----------------------------------------------------------
 ! get global domain indices
-! this assumes that domain2d type has been assigned
+! this assumes that FmsMppDomain2D type has been assigned
 
   call fms_mpp_domains_get_global_domain ( Ice%Domain, isg, ieg, jsg, jeg )
 
@@ -525,19 +525,19 @@ real :: lon0, lond, latd, amp, t_control, dellon, dom_wid, siggy, tempi
   !enddo
 
   ! set io domain if not there in order to check files
-  if ( .not. associated(mpp_get_io_domain(Ice%domain)) ) then
+  if ( .not. associated(fms_mpp_domains_get_io_domain(Ice%domain)) ) then
     call fms_mpp_domains_define_io_domain(Ice%domain, (/ 1, 1 /) )
   endif
 
   ! read the land mask from a file (land=1)
-  if (open_file(land_mask_fileobj, 'INPUT/land_mask.nc', 'read', Ice%domain)) then
-      call fms_fms2_io_read_data (land_mask_fileobj, 'land_mask', Ice%glon)
+  if (fms2_io_open_file(land_mask_fileobj, 'INPUT/land_mask.nc', 'read', Ice%domain)) then
+      call fms2_io_read_data (land_mask_fileobj, 'land_mask', Ice%glon)
       where (Ice%glon > 0.50)
          Ice%gmask = .false.
       elsewhere
          Ice%gmask = .true.
       endwhere
-      call fms_fms2_io_close_file(land_mask_fileobj)
+      call fms2_io_close_file(land_mask_fileobj)
   else
       Ice%gmask = .true.  ! aqua-planet
   endif
@@ -593,19 +593,19 @@ real :: lon0, lond, latd, amp, t_control, dellon, dom_wid, siggy, tempi
 
 need_ic = .false.
 
-if (open_file(ice_restart_fileobj, 'INPUT/ice_model.res.nc', 'read', Ice%domain, is_restart=.true.)) then
-   if (mpp_pe() == mpp_root_pe()) call error_mesg ('ice_model_mod', &
+if (fms2_io_open_file(ice_restart_fileobj, 'INPUT/ice_model.res.nc', 'read', Ice%domain, is_restart=.true.)) then
+   if (fms_mpp_pe() == fms_mpp_root_pe()) call error_mesg ('ice_model_mod', &
             'Reading NetCDF formatted restart file: INPUT/ice_model.res.nc', NOTE)
 
-   call fms_fms2_io_read_data(ice_restart_fileobj, 'mlon', mlon)
-   call fms_fms2_io_read_data(ice_restart_fileobj, 'mlat', mlat)
+   call fms2_io_read_data(ice_restart_fileobj, 'mlon', mlon)
+   call fms2_io_read_data(ice_restart_fileobj, 'mlat', mlat)
    if (mlon /= nlon .or. mlat /= nlat )  &
         call error_mesg ('ice_model_init',           &
                         'incorrect resolution on restart', FATAL)
 
    call ice_register_restart(ice_restart_fileobj, Ice)
-   call fms_fms2_io_read_restart(ice_restart_fileobj)
-   call fms_fms2_io_close_file(ice_restart_fileobj)
+   call fms2_io_read_restart(ice_restart_fileobj)
+   call fms2_io_close_file(ice_restart_fileobj)
 else
   !--- if no restart then no ice ---
       need_ic = .true.
@@ -1066,11 +1066,11 @@ endif
   if (trim(ice_method) == 'prognostic' .or. &
       trim(ice_method) == 'uniform') then
       if (trim(interp_method) == "conservative") then
-          Amip_ice = amip_interp_new ( Ice%lon_bnd(:,1),     Ice%lat_bnd(1,:),  &
+          Amip_ice = fms_amip_interp_new ( Ice%lon_bnd(:,1),     Ice%lat_bnd(1,:),  &
                          Ice%mask(:,:), interp_method = interp_method, &
                     use_climo=use_climo_ice, use_annual=use_annual_ice )
       else if(trim(interp_method) == "bilinear") then
-          Amip_ice = amip_interp_new ( Ice%lon,     Ice%lat,          &
+          Amip_ice = fms_amip_interp_new ( Ice%lon,     Ice%lat,          &
                          Ice%mask(:,:), interp_method = interp_method, &
                     use_climo=use_climo_ice, use_annual=use_annual_ice )
       else
@@ -1087,11 +1087,11 @@ endif
 
   if (trim(sst_method) == 'specified') then
       if (trim(interp_method) == "conservative") then
-          Amip_sst = amip_interp_new ( Ice%lon_bnd(:,1),     Ice%lat_bnd(1,:),  &
+          Amip_sst = fms_amip_interp_new ( Ice%lon_bnd(:,1),     Ice%lat_bnd(1,:),  &
                          Ice%mask(:,:), interp_method = interp_method, &
                     use_climo=use_climo_sst, use_annual=use_annual_sst )
       else if(trim(interp_method) == "bilinear") then
-          Amip_sst = amip_interp_new ( Ice%lon,     Ice%lat,          &
+          Amip_sst = fms_amip_interp_new ( Ice%lon,     Ice%lat,          &
                          Ice%mask(:,:), interp_method = interp_method, &
                     use_climo=use_climo_sst, use_annual=use_annual_sst )
       else
@@ -1104,13 +1104,13 @@ endif
       endif
   endif
 
-print *, 'pe,count(ice,all,ocean)=',mpp_pe(),count(Ice%ice_mask),count(Ice%mask),count(Ice%mask .and. .not.Ice%ice_mask)
+print *, 'pe,count(ice,all,ocean)=',fms_mpp_pe(),count(Ice%ice_mask),count(Ice%mask),count(Ice%mask .and. .not.Ice%ice_mask)
 
 ! add on non-zero sea surface temperature perturbation (namelist option)
 ! this perturbation may be useful in accessing model sensitivities
 
   if ( abs(sst_anom) > 0.0001 ) then
-    Ice%t_surf(:,:) = Ice%t_surf(:,:) + sst_anom
+    Ice%t_surf(:,:) = Ice%t_surf(:,:) + fms_amip_interp_sst_anom
   endif
 
 !----------------------------------------------------------
@@ -1131,25 +1131,25 @@ print *, 'pe,count(ice,all,ocean)=',mpp_pe(),count(Ice%ice_mask),count(Ice%mask)
  dim_names(2) = "yaxis_1"
  dim_names(3) = "Time"
 
- call fms_fms2_io_register_axis(fileobj, dim_names(1), "x")
- call fms_fms2_io_register_axis(fileobj, dim_names(2), "y")
- call fms_fms2_io_register_axis(fileobj, dim_names(3), unlimited)
+ call fms2_io_register_axis(fileobj, dim_names(1), "x")
+ call fms2_io_register_axis(fileobj, dim_names(2), "y")
+ call fms2_io_register_axis(fileobj, dim_names(3), unlimited)
 
  !< Register the domain decomposed dimensions as variables so that the combiner can work
  !! correctly
- call fms_fms2_io_register_field(fileobj, dim_names(1), "double", (/dim_names(1)/))
- call fms_fms2_io_register_field(fileobj, dim_names(2), "double", (/dim_names(2)/))
+ call fms2_io_register_field(fileobj, dim_names(1), "double", (/dim_names(1)/))
+ call fms2_io_register_field(fileobj, dim_names(2), "double", (/dim_names(2)/))
 
- call fms_fms2_io_register_restart_field ( fileobj, 't_surf',         Ice%t_surf,         dim_names )
- call fms_fms2_io_register_restart_field ( fileobj, 'thickness',      Ice%thickness,      dim_names )
- call fms_fms2_io_register_restart_field ( fileobj, 'albedo',         Ice%albedo,         dim_names )
- call fms_fms2_io_register_restart_field ( fileobj, 'albedo_vis_dir', Ice%albedo_vis_dir, dim_names )
- call fms_fms2_io_register_restart_field ( fileobj, 'albedo_nir_dir', Ice%albedo_nir_dir, dim_names )
- call fms_fms2_io_register_restart_field ( fileobj, 'albedo_vis_dif', Ice%albedo_vis_dif, dim_names )
- call fms_fms2_io_register_restart_field ( fileobj, 'albedo_nir_dif', Ice%albedo_nir_dif, dim_names )
- call fms_fms2_io_register_restart_field ( fileobj, 'rough_mom',      Ice%rough_mom,      dim_names )
- call fms_fms2_io_register_restart_field ( fileobj, 'rough_heat',     Ice%rough_heat,     dim_names )
- call fms_fms2_io_register_restart_field ( fileobj, 'rough_moist',    Ice%rough_moist,    dim_names )
+ call fms2_io_register_restart_field ( fileobj, 't_surf',         Ice%t_surf,         dim_names )
+ call fms2_io_register_restart_field ( fileobj, 'thickness',      Ice%thickness,      dim_names )
+ call fms2_io_register_restart_field ( fileobj, 'albedo',         Ice%albedo,         dim_names )
+ call fms2_io_register_restart_field ( fileobj, 'albedo_vis_dir', Ice%albedo_vis_dir, dim_names )
+ call fms2_io_register_restart_field ( fileobj, 'albedo_nir_dir', Ice%albedo_nir_dir, dim_names )
+ call fms2_io_register_restart_field ( fileobj, 'albedo_vis_dif', Ice%albedo_vis_dif, dim_names )
+ call fms2_io_register_restart_field ( fileobj, 'albedo_nir_dif', Ice%albedo_nir_dif, dim_names )
+ call fms2_io_register_restart_field ( fileobj, 'rough_mom',      Ice%rough_mom,      dim_names )
+ call fms2_io_register_restart_field ( fileobj, 'rough_heat',     Ice%rough_heat,     dim_names )
+ call fms2_io_register_restart_field ( fileobj, 'rough_moist',    Ice%rough_moist,    dim_names )
 
  end subroutine ice_register_restart
 
@@ -1164,20 +1164,20 @@ print *, 'pe,count(ice,all,ocean)=',mpp_pe(),count(Ice%ice_mask),count(Ice%mask)
  if (.not.module_is_initialized) return
  if( do_netcdf_restart) then
 
-    if(mpp_pe() == mpp_root_pe() ) then
+    if(fms_mpp_pe() == fms_mpp_root_pe() ) then
        call error_mesg ('ice_model_mod', 'Writing NetCDF formatted restart file: RESTART/ice_model.res.nc', NOTE)
     endif
 
-    if (open_file(ice_restart_fileobj, fname, 'overwrite', Ice%domain, is_restart=.true.)) then
+    if (fms2_io_open_file(ice_restart_fileobj, fname, 'overwrite', Ice%domain, is_restart=.true.)) then
         call ice_register_restart(ice_restart_fileobj, Ice)
-        call fms_fms2_io_register_field(ice_restart_fileobj, "mlon", "double")
-        call fms_fms2_io_register_field(ice_restart_fileobj, "mlat", "double")
-        call fms_fms2_io_write_restart(ice_restart_fileobj)
-        call fms_fms2_io_write_data(ice_restart_fileobj, 'mlon', size(Ice%gmask,1))
-        call fms_fms2_io_write_data(ice_restart_fileobj, 'mlat', size(Ice%gmask,2))
+        call fms2_io_register_field(ice_restart_fileobj, "mlon", "double")
+        call fms2_io_register_field(ice_restart_fileobj, "mlat", "double")
+        call fms2_io_write_restart(ice_restart_fileobj)
+        call fms2_io_write_data(ice_restart_fileobj, 'mlon', size(Ice%gmask,1))
+        call fms2_io_write_data(ice_restart_fileobj, 'mlat', size(Ice%gmask,2))
         call add_domain_dimension_data(ice_restart_fileobj)
-        call fms_fms2_io_close_file(ice_restart_fileobj)
-    endif !< if(open_file)
+        call fms2_io_close_file(ice_restart_fileobj)
+    endif !< if(fms2_io_open_file)
  endif
 
 
@@ -1197,12 +1197,12 @@ print *, 'pe,count(ice,all,ocean)=',mpp_pe(),count(Ice%ice_mask),count(Ice%mask)
   integer, dimension(:), allocatable :: buffer !< Buffer with axis data
   integer :: is, ie !< Starting and Ending indices for data
 
-    call fms_fms2_io_get_global_io_domain_indices(fileobj, "xaxis_1", is, ie, indices=buffer)
-    call fms_fms2_io_write_data(fileobj, "xaxis_1", buffer)
+    call fms2_io_get_global_io_domain_indices(fileobj, "xaxis_1", is, ie, indices=buffer)
+    call fms2_io_write_data(fileobj, "xaxis_1", buffer)
     deallocate(buffer)
 
-    call fms_fms2_io_get_global_io_domain_indices(fileobj, "yaxis_1", is, ie, indices=buffer)
-    call fms_fms2_io_write_data(fileobj, "yaxis_1", buffer)
+    call fms2_io_get_global_io_domain_indices(fileobj, "yaxis_1", is, ie, indices=buffer)
+    call fms2_io_write_data(fileobj, "yaxis_1", buffer)
     deallocate(buffer)
  end subroutine add_domain_dimension_data
 

--- a/simple/ice_model.F90
+++ b/simple/ice_model.F90
@@ -27,7 +27,7 @@ use ocean_albedo_mod, only:  compute_ocean_albedo_new
 use  ocean_rough_mod, only:  compute_ocean_roughness, fixed_ocean_roughness
 
 !! FMS
-use FMS!,              only: fms_amip_interp_sst_anom
+use FMS
 use FMSconstants,     only: HLV, HLF, TFREEZE, pi
 
 implicit none
@@ -100,7 +100,7 @@ namelist /ice_model_nml/ diff, thickness_min, specified_ice_thickness,        &
                          heat_capacity_ocean, temp_ice_freeze, roughness_ice, &
                          ice_method, use_climo_ice, use_annual_ice, temp_ice, &
                          sst_method, use_climo_sst, use_annual_sst, temp_sst, &
-                         interp_method, do_netcdf_restart, fms_amip_interp_sst_anom
+                         interp_method, do_netcdf_restart, sst_anom
 
 !----------------------------------------------------------------
 


### PR DESCRIPTION
This changes all the FMS routine calls, derived types, and modules to be updated with FMS's most up-to-date naming conventions. All FMS references will be denoted with `fms` as a prefix

This PR is dependent on https://github.com/NOAA-GFDL/FMS/pull/1262