### PR TITLE
add missed routine prefixes from libfms

### DIFF
--- a/SHiELD/coupler_main.F90
+++ b/SHiELD/coupler_main.F90
@@ -217,7 +217,7 @@ contains
 !----- read namelist -------
 !----- for backwards compatibilty read from file coupler.nml -----
    read(fms_mpp_input_nml_file, nml=coupler_nml, iostat=io)
-   ierr = check_nml_error(io, 'coupler_nml')
+   ierr = fms_check_nml_error(io, 'coupler_nml')
 
 !----- write namelist to logfile -----
    call fms_write_version_number (version, tag)
@@ -241,7 +241,7 @@ contains
 !----- use namelist value (either no restart or override flag on) ---
     if ( force_date_from_namelist ) then
       if ( sum(current_date) <= 0 ) then
-         call error_mesg ('program coupler',  &
+         call fms_error_mesg ('program coupler',  &
               'no namelist value for current_date', FATAL)
       else
          date      = current_date
@@ -299,7 +299,7 @@ contains
 !
 !   (NOTE: if run length in months then starting day must be <= 28)
     if ( months > 0 .and. date(3) > 28 )     &
-        call error_mesg ('program coupler',  &
+        call fms_error_mesg ('program coupler',  &
        'if run length in months then starting day must be <= 28', FATAL)
 
     Time_end = Time_atmos
@@ -365,19 +365,19 @@ contains
 
 !----- initial time cannot be greater than current time -------
 
-    if ( Time_init > Time_atmos ) call error_mesg ('program coupler',  &
+    if ( Time_init > Time_atmos ) call fms_error_mesg ('program coupler',  &
                     'initial time is greater than current time', FATAL)
 
 !----- make sure run length is a multiple of ocean time step ------
 
     if ( num_cpld_calls * Time_step_ocean /= Run_length )  &
-         call error_mesg ('program coupler',  &
+         call fms_error_mesg ('program coupler',  &
          'run length must be multiple of ocean time step', FATAL)
 
 ! ---- make sure cpld time step is a multiple of atmos time step ----
 
     if ( num_atmos_calls * Time_step_atmos /= Time_step_ocean )  &
-         call error_mesg ('program coupler',   &
+         call fms_error_mesg ('program coupler',   &
          'atmos time step is not a multiple of the ocean time step', FATAL)
 
 !------ initialize component models ------
@@ -449,7 +449,7 @@ contains
 
 !----- check time versus expected ending time ----
 
-      if (Time_atmos /= Time_end) call error_mesg ('program coupler',  &
+      if (Time_atmos /= Time_end) call fms_error_mesg ('program coupler',  &
               'final time does not match expected ending time', WARNING)
 
 !----- write restart file ------

--- a/full/atm_land_ice_flux_exchange.F90
+++ b/full/atm_land_ice_flux_exchange.F90
@@ -422,12 +422,12 @@ contains
     enddo
 
     if (isphum==NO_TRACER) then
-       call error_mesg('atm_land_ice_flux_exchange_mod',&
+       call fms_error_mesg('atm_land_ice_flux_exchange_mod',&
             'tracer "sphum" must be present in the atmosphere', FATAL )
     endif
 
     if (ico2==NO_TRACER) then
-       call error_mesg('atm_land_ice_flux_exchange_mod',&
+       call fms_error_mesg('atm_land_ice_flux_exchange_mod',&
             'tracer "co2" not present in the atmosphere', NOTE )
     endif
 
@@ -715,7 +715,7 @@ contains
     integer :: isc,iec,jsc,jec
 
     ! [1] check that the module was initialized
-    if (do_init) call error_mesg ('atm_land_ice_flux_exchange_mod',  &
+    if (do_init) call fms_error_mesg ('atm_land_ice_flux_exchange_mod',  &
          'must call atm_land_ice_flux_exchange_init first', FATAL)
     !Balaji
     call fms_mpp_clock_begin(cplClock)
@@ -3698,7 +3698,7 @@ contains
     !    needed for cmorizing various diagnostics.
     !--------------------------------------------------------------------
     area_id = fms_diag_get_field_id ('dynamics', 'area')
-    if (area_id .eq. DIAG_FIELD_NOT_FOUND) call error_mesg &
+    if (area_id .eq. DIAG_FIELD_NOT_FOUND) call fms_error_mesg &
          ('diag_field_init in atm_land_ice_flux_exchange_mod', &
          'diagnostic field "dynamics", "area" is not in the diag_table', NOTE)
 

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -1208,7 +1208,7 @@ contains
 !----- read namelist -------
 
     read (fms_mpp_input_nml_file, coupler_nml, iostat=io)
-    ierr = check_nml_error (io, 'coupler_nml')
+    ierr = fms_check_nml_error (io, 'coupler_nml')
 
 !----- read date and calendar type from restart file -----
     if (fms2_io_file_exists('INPUT/coupler.res')) then
@@ -1226,7 +1226,7 @@ contains
     if ( force_date_from_namelist ) then
 
       if ( sum(current_date) <= 0 ) then
-        call error_mesg ('program coupler',  &
+        call fms_error_mesg ('program coupler',  &
              'no namelist value for base_date or current_date', FATAL)
       else
         date      = current_date
@@ -1658,19 +1658,19 @@ contains
 
 !----- initial time cannot be greater than current time -------
 
-    if ( Time_init > Time ) call error_mesg ('program coupler',  &
+    if ( Time_init > Time ) call fms_error_mesg ('program coupler',  &
          'initial time is greater than current time', FATAL)
 
 !----- make sure run length is a multiple of ocean time step ------
 
     if ( num_cpld_calls * Time_step_cpld  /= Run_length )  &
-      call error_mesg ('program coupler',  &
+      call fms_error_mesg ('program coupler',  &
          'run length must be multiple of coupled time step', FATAL)
 
 ! ---- make sure cpld time step is a multiple of atmos time step ----
 
     if ( num_atmos_calls * Time_step_atmos /= Time_step_cpld )  &
-      call error_mesg ('program coupler',   &
+      call fms_error_mesg ('program coupler',   &
          'cpld time step is not a multiple of the atmos time step', FATAL)
 
 !
@@ -1979,7 +1979,7 @@ contains
 
 !----- check time versus expected ending time ----
 
-    if (Time /= Time_end) call error_mesg ('program coupler',  &
+    if (Time /= Time_end) call fms_error_mesg ('program coupler',  &
          'final time does not match expected ending time', WARNING)
 
 !-----------------------------------------------------------------------

--- a/full/flux_exchange.F90
+++ b/full/flux_exchange.F90
@@ -728,17 +728,17 @@ contains
     !----- read namelist -------
 
     read (fms_mpp_input_nml_file, flux_exchange_nml, iostat=io)
-    ierr = check_nml_error (io, 'flux_exchange_nml')
+    ierr = fms_check_nml_error (io, 'flux_exchange_nml')
 
     !----- write namelist to logfile -----
     call fms_write_version_number (version, tag)
     if( fms_mpp_pe() == fms_mpp_root_pe() )write( logunit, nml=flux_exchange_nml )
-    if(nblocks<1) call error_mesg ('flux_exchange_mod',  &
+    if(nblocks<1) call fms_error_mesg ('flux_exchange_mod',  &
          'flux_exchange_nml nblocks must be positive', FATAL)
     if(nblocks .NE. nthreads) then
        write(errmsg, '(a,i3,a,i3)')'flux_exchange_nml nblocks is set to ', nblocks, &
             ' is different from the default value (number of threads) = ', nthreads
-       call error_mesg ('flux_exchange_mod', errmsg, NOTE)
+       call fms_error_mesg ('flux_exchange_mod', errmsg, NOTE)
     endif
 
     ! required by stock_move, all fluxes used to update stocks will be zero if dt_atmos,
@@ -904,12 +904,12 @@ contains
     call fms_mpp_get_current_pelist(pes)
 
     if ( .not. fms2_io_open_file(grid_file_obj, grid_file, "read", pelist=pes)) then
-         call error_mesg ('atm_land_ice_flux_exchange_mod',  &
+         call fms_error_mesg ('atm_land_ice_flux_exchange_mod',  &
               & 'Error opening '//trim(grid_file), FATAL)
     endif
 
     if(size(Atm%lon_bnd,1) .NE. iec-isc+2 .OR. size(Atm%lon_bnd,2) .NE. jec-jsc+2) then
-       call error_mesg ('atm_land_ice_flux_exchange_mod',  &
+       call fms_error_mesg ('atm_land_ice_flux_exchange_mod',  &
             'size of Atm%lon_bnd does not match the Atm computational domain', FATAL)
     endif
     ioff = lbound(Atm%lon_bnd,1) - isc
@@ -926,7 +926,7 @@ contains
                   'atmosphere has', nxg, 'longitudes,', &
                   nyg, 'latitudes (see xba.dat and yba.dat)'
           end if
-          call error_mesg ('atm_land_ice_flux_exchange_mod',  &
+          call fms_error_mesg ('atm_land_ice_flux_exchange_mod',  &
                'grid_spec.nc incompatible with atmosphere resolution', FATAL)
        end if
        allocate( atmlonb(isg:ieg+1) )
@@ -938,7 +938,7 @@ contains
           if(abs(atmlonb(i)-Atm%lon_bnd(i+ioff,jsc+joff)*45.0/atan(1.0))>bound_tol) then
              print *, 'GRID_SPEC/ATMOS LONGITUDE INCONSISTENCY at i= ',i, ': ', &
                   atmlonb(i),  Atm%lon_bnd(i+ioff,jsc+joff)*45.0/atan(1.0)
-             call error_mesg ('atm_land_ice_flux_exchange_mod', &
+             call fms_error_mesg ('atm_land_ice_flux_exchange_mod', &
                   'grid_spec.nc incompatible with atmosphere longitudes (see xba.dat and yba.dat)'&
                   , FATAL)
           endif
@@ -947,7 +947,7 @@ contains
           if(abs(atmlatb(j)-Atm%lat_bnd(isc+ioff,j+joff)*45.0/atan(1.0))>bound_tol) then
              print *, 'GRID_SPEC/ATMOS LATITUDE INCONSISTENCY at j= ',j, ': ', &
                   atmlatb(j),  Atm%lat_bnd(isc+ioff, j+joff)*45.0/atan(1.0)
-             call error_mesg ('atm_land_ice_flux_exchange_mod', &
+             call fms_error_mesg ('atm_land_ice_flux_exchange_mod', &
                   'grid_spec.nc incompatible with atmosphere latitudes (see xba.dat and yba.dat)'&
                   , FATAL)
           endif
@@ -957,7 +957,7 @@ contains
        call fms2_io_read_data(grid_file_obj, 'atm_mosaic_file', atm_mosaic_file)
 
        if ( .not. fms2_io_open_file(atm_mosaic_file_obj, "INPUT/"//trim(atm_mosaic_file)//"", "read", pelist=pes)) then
-           call error_mesg ('atm_land_ice_flux_exchange_mod',  &
+           call fms_error_mesg ('atm_land_ice_flux_exchange_mod',  &
               & 'Error opening '//trim(atm_mosaic_file), FATAL)
        endif
 
@@ -985,7 +985,7 @@ contains
 
        !< This is will open the correct atm_mosaic_file for the current tile, i.e "C96_grid.tile1.nc"
        if ( .not. fms2_io_open_file(tile_file_obj, "INPUT/"//trim(tile_file)//"", "read", domain2)) then
-          call error_mesg ('atm_land_ice_flux_exchange_mod',  &
+          call fms_error_mesg ('atm_land_ice_flux_exchange_mod',  &
               & 'Error opening '//trim(tile_file), FATAL)
        endif
 
@@ -1002,7 +1002,7 @@ contains
              print *, 'atmosphere mosaic tile has', nlon, 'longitudes,', nlat, 'latitudes; ', &
                   'atmosphere has', nxg, 'longitudes,', nyg, 'latitudes'
           end if
-          call error_mesg ('atm_land_ice_flux_exchange_mod',  &
+          call fms_error_mesg ('atm_land_ice_flux_exchange_mod',  &
                'atmosphere mosaic tile grid file incompatible with atmosphere resolution', FATAL)
        end if
 
@@ -1028,14 +1028,14 @@ contains
              if (abs(tmpx(2*i-1,2*j-1)-Atm%lon_bnd(i+ioff,j+joff)*45.0/atan(1.0))>bound_tol) then
                 print *, 'GRID_SPEC/ATMOS LONGITUDE INCONSISTENCY at i= ',i, ', j= ', j, ': ', &
                      tmpx(2*i-1,2*j-1),  Atm%lon_bnd(i+ioff,j+joff)*45.0/atan(1.0)
-                call error_mesg ('atm_land_ice_flux_exchange_mod', &
+                call fms_error_mesg ('atm_land_ice_flux_exchange_mod', &
                      'grid_spec.nc incompatible with atmosphere longitudes (see '//trim(tile_file)//')'&
                      ,FATAL)
              end if
              if (abs(tmpy(2*i-1,2*j-1)-Atm%lat_bnd(i+ioff,j+joff)*45.0/atan(1.0))>bound_tol) then
                 print *, 'GRID_SPEC/ATMOS LATITUDE INCONSISTENCY at i= ',i, ', j= ', j, ': ', &
                      tmpy(2*i-1,2*j-1),  Atm%lat_bnd(i+ioff,j+joff)*45.0/atan(1.0)
-                call error_mesg ('atm_land_ice_flux_exchange_mod', &
+                call fms_error_mesg ('atm_land_ice_flux_exchange_mod', &
                      'grid_spec.nc incompatible with atmosphere latitudes (see '//trim(tile_file)//')'&
                      ,FATAL)
              end if

--- a/shared/surface_flux.F90
+++ b/shared/surface_flux.F90
@@ -682,7 +682,7 @@ subroutine surface_flux_init
 
   ! read namelist
   read (fms_mpp_input_nml_file, surface_flux_nml, iostat=io)
-  ierr = check_nml_error(io,'surface_flux_nml')
+  ierr = fms_check_nml_error(io,'surface_flux_nml')
 
   ! write version number
   call fms_write_version_number(version, tagname)

--- a/simple/coupler_main.F90
+++ b/simple/coupler_main.F90
@@ -269,7 +269,7 @@ contains
 !----- for backwards compatibilty read from file coupler.nml -----
 
     read (fms_mpp_input_nml_file, nml=coupler_nml, iostat=io)
-    ierr = check_nml_error(io, 'coupler_nml')
+    ierr = fms_check_nml_error(io, 'coupler_nml')
 
 !----- write namelist to logfile -----
 
@@ -297,7 +297,7 @@ contains
     if ( force_date_from_namelist ) then
 
       if ( sum(current_date) <= 0 ) then
-        call error_mesg ('program coupler',  &
+        call fms_error_mesg ('program coupler',  &
              'no namelist value for current_date', FATAL)
       else
         date      = current_date
@@ -365,7 +365,7 @@ contains
 !   (NOTE: if run length in months then starting day must be <= 28)
 
     if ( months > 0 .and. date(3) > 28 )     &
-       call error_mesg ('program coupler',  &
+       call fms_error_mesg ('program coupler',  &
             'if run length in months then starting day must be <= 28', FATAL)
 
     Time_end = Time_atmos
@@ -413,19 +413,19 @@ contains
 
 !----- initial time cannot be greater than current time -------
 
-    if ( Time_init > Time_atmos ) call error_mesg ('program coupler',  &
+    if ( Time_init > Time_atmos ) call fms_error_mesg ('program coupler',  &
                     'initial time is greater than current time', FATAL)
 
 !----- make sure run length is a multiple of ocean time step ------
 
     if ( num_cpld_calls * Time_step_ocean /= Run_length )  &
-         call error_mesg ('program coupler',  &
+         call fms_error_mesg ('program coupler',  &
          'run length must be multiple of ocean time step', FATAL)
 
 ! ---- make sure cpld time step is a multiple of atmos time step ----
 
     if ( num_atmos_calls * Time_step_atmos /= Time_step_ocean )  &
-         call error_mesg ('program coupler',   &
+         call fms_error_mesg ('program coupler',   &
          'atmos time step is not a multiple of the ocean time step', FATAL)
 
 
@@ -491,7 +491,7 @@ contains
 
 !----- check time versus expected ending time ----
 
-    if (Time_atmos /= Time_end) call error_mesg ('program coupler',  &
+    if (Time_atmos /= Time_end) call fms_error_mesg ('program coupler',  &
             'final time does not match expected ending time', WARNING)
 
 !----- write restart file ------

--- a/simple/flux_exchange.F90
+++ b/simple/flux_exchange.F90
@@ -160,7 +160,7 @@ real :: zrefm, zrefh
 
 !-----------------------------------------------------------------------
 
-   if (do_init) call error_mesg ('sfc_boundary_layer',  &
+   if (do_init) call fms_error_mesg ('sfc_boundary_layer',  &
                  'must call simple_surface_init first', FATAL)
 
 !-----------------------------------------------------------------------
@@ -685,13 +685,13 @@ subroutine flux_up_to_atmos (Time, Land, Ice, Boundary )
                             num_prog=n_atm_tr)
    isphum = fms_tracer_manager_get_tracer_index( MODEL_ATMOS, 'sphum' )
    if (isphum==NO_TRACER) &
-      call error_mesg('flux_exchange_mod', 'Cannot find water vapor in ATM tracer table', FATAL)
+      call fms_error_mesg('flux_exchange_mod', 'Cannot find water vapor in ATM tracer table', FATAL)
 !-----------------------------------------------------------------------
 !------ allocate atmos_land_boundary ------
 
    call fms_mpp_domains_get_compute_domain ( Land%Domain, isc, iec, jsc, jec )
    if (isc /= is .or. iec /= ie .or. jsc /= js .or. jec /= je ) &
-         call error_mesg ('flux_exchange_init', 'land model '// &
+         call fms_error_mesg ('flux_exchange_init', 'land model '// &
                 'domain does not match atmosphere domain', FATAL)
    kd = size(Land%mask,3) ! must be 1 (should check)
  ! allocate( atmos_land_boundary%t_flux (is:ie,js:je,kd) )
@@ -735,7 +735,7 @@ subroutine flux_up_to_atmos (Time, Land, Ice, Boundary )
 
    call fms_mpp_domains_get_compute_domain ( Ice%Domain, isc, iec, jsc, jec )
    if (isc /= is .or. iec /= ie .or. jsc /= js .or. jec /= je ) &
-          call error_mesg ('flux_exchange_init', 'ice model '// &
+          call fms_error_mesg ('flux_exchange_init', 'ice model '// &
                 'domain does not match atmosphere domain', FATAL)
 
    allocate( atmos_ice_boundary%u_star(is:ie,js:je) )
@@ -837,7 +837,7 @@ subroutine flux_up_to_atmos (Time, Land, Ice, Boundary )
  integer :: ierr, io
 
    read (fms_mpp_input_nml_file, nml=flux_exchange_nml, iostat=io)
-   ierr = check_nml_error(io, 'flux_exchange_nml')
+   ierr = fms_check_nml_error(io, 'flux_exchange_nml')
 
    do_read_nml = .false.
 
@@ -1056,7 +1056,7 @@ subroutine diag_field_init ( Time, atmos_axes )
     !    needed for cmorizing various diagnostics.
     !--------------------------------------------------------------------
     area_id = fms_diag_get_field_id ('dynamics', 'area')
-    if (area_id .eq. DIAG_FIELD_NOT_FOUND) call error_mesg &
+    if (area_id .eq. DIAG_FIELD_NOT_FOUND) call fms_error_mesg &
          ('diag_field_init in atm_land_ice_flux_exchange_mod', &
          'diagnostic field "dynamics", "area" is not in the diag_table', NOTE)
     !-----------------------------------------------------------------------

--- a/simple/ice_model.F90
+++ b/simple/ice_model.F90
@@ -429,7 +429,7 @@ real :: lon0, lond, latd, amp, t_control, dellon, dom_wid, siggy, tempi
 
  !< Read the namelist
  read (fms_mpp_input_nml_file, nml=ice_model_nml, iostat=io)
- ierr = check_nml_error(io, 'ice_model_nml')
+ ierr = fms_check_nml_error(io, 'ice_model_nml')
 
  do_netcdf_restart = .true. !< Always do netcdf!
 
@@ -442,7 +442,7 @@ real :: lon0, lond, latd, amp, t_control, dellon, dom_wid, siggy, tempi
 
   if ( trim(ice_method) /= 'none'    .and. &
        trim(ice_method) /= 'uniform' .and. &
-       trim(ice_method) /= 'prognostic' ) call error_mesg &
+       trim(ice_method) /= 'prognostic' ) call fms_error_mesg &
      ('ice_model_init', 'namelist variable ice_method has invalid value', FATAL)
 
   if ( trim(sst_method) /= 'specified'            .and. &
@@ -478,7 +478,7 @@ real :: lon0, lond, latd, amp, t_control, dellon, dom_wid, siggy, tempi
        trim(sst_method) /= 'aqua_walker_guass_b'  .and. &
        trim(sst_method) /= 'aqua_walker_guass_c'  .and. &
        trim(sst_method) /= 'aqua_walker_guass_d'  .and. &
-       trim(sst_method) /= 'mixed_layer' ) call error_mesg &
+       trim(sst_method) /= 'mixed_layer' ) call fms_error_mesg &
      ('ice_model_init', 'namelist variable sst_method has invalid value', FATAL)
 
 !----------------------------------------------------------
@@ -594,13 +594,13 @@ real :: lon0, lond, latd, amp, t_control, dellon, dom_wid, siggy, tempi
 need_ic = .false.
 
 if (fms2_io_open_file(ice_restart_fileobj, 'INPUT/ice_model.res.nc', 'read', Ice%domain, is_restart=.true.)) then
-   if (fms_mpp_pe() == fms_mpp_root_pe()) call error_mesg ('ice_model_mod', &
+   if (fms_mpp_pe() == fms_mpp_root_pe()) call fms_error_mesg ('ice_model_mod', &
             'Reading NetCDF formatted restart file: INPUT/ice_model.res.nc', NOTE)
 
    call fms2_io_read_data(ice_restart_fileobj, 'mlon', mlon)
    call fms2_io_read_data(ice_restart_fileobj, 'mlat', mlat)
    if (mlon /= nlon .or. mlat /= nlat )  &
-        call error_mesg ('ice_model_init',           &
+        call fms_error_mesg ('ice_model_init',           &
                         'incorrect resolution on restart', FATAL)
 
    call ice_register_restart(ice_restart_fileobj, Ice)
@@ -1074,7 +1074,7 @@ endif
                          Ice%mask(:,:), interp_method = interp_method, &
                     use_climo=use_climo_ice, use_annual=use_annual_ice )
       else
-          call error_mesg ('ice_model_init', 'interp_method should be '// &
+          call fms_error_mesg ('ice_model_init', 'interp_method should be '// &
                            'conservative or bilinear', FATAL)
       endif
       ! initialize ice (if needed)
@@ -1095,7 +1095,7 @@ endif
                          Ice%mask(:,:), interp_method = interp_method, &
                     use_climo=use_climo_sst, use_annual=use_annual_sst )
       else
-          call error_mesg ('ice_model_init', 'interp_method should be '// &
+          call fms_error_mesg ('ice_model_init', 'interp_method should be '// &
                            'conservative or bilinear', FATAL)
       endif
       ! initialize sst (if needed)
@@ -1165,7 +1165,7 @@ print *, 'pe,count(ice,all,ocean)=',fms_mpp_pe(),count(Ice%ice_mask),count(Ice%m
  if( do_netcdf_restart) then
 
     if(fms_mpp_pe() == fms_mpp_root_pe() ) then
-       call error_mesg ('ice_model_mod', 'Writing NetCDF formatted restart file: RESTART/ice_model.res.nc', NOTE)
+       call fms_error_mesg ('ice_model_mod', 'Writing NetCDF formatted restart file: RESTART/ice_model.res.nc', NOTE)
     endif
 
     if (fms2_io_open_file(ice_restart_fileobj, fname, 'overwrite', Ice%domain, is_restart=.true.)) then


### PR DESCRIPTION
replace error_mesg and check_nml_error calls with their prefixed names since they were missed in the original update

needs https://github.com/NOAA-GFDL/FMS/pull/1303