### PR TITLE
Pass Ocean_ice_boundary to combined Ice-ocean driver

### DIFF
--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -1054,7 +1054,7 @@ program coupler_main
       if (combined_ice_and_ocean) then
         call flux_ice_to_ocean_stocks(Ice)
         call update_slow_ice_and_ocean(ice_ocean_driver_CS, Ice, Ocean_state, Ocean, &
-                      Ice_ocean_boundary, Time_ocean, Time_step_cpld )
+                      Ice_ocean_boundary, Time_ocean, Time_step_cpld, OIB=Ocean_ice_boundary)
       else
       if (do_chksum) call ocean_chksum('update_ocean_model-', nc, Ocean, Ice_ocean_boundary)
       ! update_ocean_model since fluxes don't change here


### PR DESCRIPTION
Adds a needed optional argument to the update_slow_ice_and_ocean call to pass the Ocean_ice_boundary type. This new optional argument is needed to properly use the interspersed coupling option.

This change should not impact the solutions to any experiments not using the combined-ice ocean driver. At compile time the new optional argument requires a SIS2 version with commit 0006cd2 or ice_null version with commit c9afb0d. 

This PR is to associated with Issue #90. 