### PR TITLE
Update CI to use github container registry image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: noaagfdl/hpc-me.ubuntu-minimal:coupler
+      image: ghcr.io/noaa-gfdl/fms/fms-ci-rocky-gnu:12.3.0
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.github_token }}
       env: 
         CC: mpicc
         FC: mpif90

--- a/t/null_model_build.sh
+++ b/t/null_model_build.sh
@@ -181,7 +181,7 @@ cd ${bld_dir}/run
 mkdir RESTART
 # Get the data files required for the run
 tarFile=coupler_null_test_data_full_simple.tar.gz
-wget ftp://ftp.gfdl.noaa.gov/perm/GFDL_pubrelease/test_data/${tarFile}
+curl -O ftp://ftp.gfdl.noaa.gov/perm/GFDL_pubrelease/test_data/${tarFile}
 tar zxf ${tarFile}
 
 # add an io layout to the full nml

--- a/t/null_model_build.sh
+++ b/t/null_model_build.sh
@@ -99,7 +99,7 @@ EOF
 mkdir -p $bld_dir/fms
 list_paths -o $bld_dir/fms/pathnames_fms $src_dir/FMS
 cd $bld_dir/fms
-mkmf -m Makefile -a $src_dir -b $bld_dir -p libfms.a -t $mkmf_template -g -c "-Duse_netCDF -Duse_libMPI -DMAXFIELDS_=200 -DMAXFIELDMETHODS_=200 -DINTERNAL_FILE_NML -DHAVE_GETTID" -IFMS/include -IFMS/mpp/include $bld_dir/fms/pathnames_fms
+mkmf -m Makefile -a $src_dir -b $bld_dir -p libfms.a -t $mkmf_template -g -c "-Duse_netCDF -Duse_libMPI -DMAXFIELDS_=200 -DMAXFIELDMETHODS_=200 -DINTERNAL_FILE_NML -DHAVE_GETTID" -o "-fallow-argument-mismatch" -IFMS/include -IFMS/mpp/include $bld_dir/fms/pathnames_fms
 cd $bld_dir
 
 # libocean_null


### PR DESCRIPTION
Switches out the container image. Needed two small changes to the test script in order run on the new image.