### PR TITLE
Passing additional surface variables into the atmospheric model #92

### DIFF
--- a/full/atm_land_ice_flux_exchange.F90
+++ b/full/atm_land_ice_flux_exchange.F90
@@ -109,7 +109,7 @@ use FMSconstants, only: rdgas, rvgas, cp_air, stefan, WTMAIR, HLV, HLF, Radius, 
              id_u_star, id_b_star, id_q_star, id_u_flux, id_v_flux,   &
              id_t_surf, id_t_flux, id_r_flux, id_q_flux, id_slp,      &
              id_t_atm,  id_u_atm,  id_v_atm,  id_wind,                &
-             id_thv_atm, id_thv_surf,                                 & ! ZNT
+             id_thv_atm, id_thv_surf,                                 &
              id_t_ref,  id_rh_ref, id_u_ref,  id_v_ref, id_wind_ref,  &
              id_del_h,  id_del_m,  id_del_q,  id_rough_scale,         &
              id_t_ca,   id_q_surf, id_q_atm, id_z_atm, id_p_atm, id_gust, &
@@ -572,9 +572,9 @@ contains
     allocate( land_ice_atmos_boundary%shflx(is:ie,js:je) )!miz
     allocate( land_ice_atmos_boundary%lhflx(is:ie,js:je) )!miz
 #endif
-    allocate( land_ice_atmos_boundary%wind(is:ie,js:je) )    !ZNT
-    allocate( land_ice_atmos_boundary%thv_atm(is:ie,js:je) ) !ZNT
-    allocate( land_ice_atmos_boundary%thv_surf(is:ie,js:je) )!ZNT
+    allocate( land_ice_atmos_boundary%wind(is:ie,js:je) )
+    allocate( land_ice_atmos_boundary%thv_atm(is:ie,js:je) )
+    allocate( land_ice_atmos_boundary%thv_surf(is:ie,js:je) )
     allocate( land_ice_atmos_boundary%rough_mom(is:ie,js:je) )
     allocate( land_ice_atmos_boundary%frac_open_sea(is:ie,js:je) )
     ! initialize boundary values for override experiments (mjh)
@@ -602,9 +602,9 @@ contains
     land_ice_atmos_boundary%shflx=0.0
     land_ice_atmos_boundary%lhflx=0.0
 #endif
-    land_ice_atmos_boundary%wind=0.0     ! ZNT
-    land_ice_atmos_boundary%thv_atm=0.0  ! ZNT
-    land_ice_atmos_boundary%thv_surf=0.0 ! ZNT
+    land_ice_atmos_boundary%wind=0.0
+    land_ice_atmos_boundary%thv_atm=0.0
+    land_ice_atmos_boundary%thv_surf=0.0
     land_ice_atmos_boundary%rough_mom=0.01
     land_ice_atmos_boundary%frac_open_sea=0.0
 
@@ -686,7 +686,7 @@ contains
          ex_rough_mom, ex_rough_heat, ex_rough_moist, &
          ex_rough_scale,&
          ex_q_star,     &
-         ex_thv_atm, ex_thv_surf, & ! ZNT
+         ex_thv_atm, ex_thv_surf, &
          ex_cd_q,       &
          ex_ref, ex_ref_u, ex_ref_v, ex_u10, &
          ex_ref2,       &
@@ -1137,7 +1137,7 @@ contains
     !$OMP                                  ex_gust,ex_flux_t,ex_flux_tr,ex_flux_lw, &
     !$OMP                                  ex_flux_u,ex_flux_v,ex_cd_m,ex_cd_t,ex_cd_q, &
     !$OMP                                  ex_wind,ex_u_star,ex_b_star,ex_q_star,       &
-    !$OMP                                  ex_thv_atm,ex_thv_surf,                      &  ! ZNT
+    !$OMP                                  ex_thv_atm,ex_thv_surf,                      &
     !$OMP                                  ex_dhdt_surf,ex_dedt_surf,ex_dfdtr_surf,   &
     !$OMP                                  ex_drdt_surf,ex_dhdt_atm,ex_dfdtr_atm,   &
     !$OMP                                  ex_dtaudu_atm, ex_dtaudv_atm,dt,ex_land, &
@@ -1155,7 +1155,7 @@ contains
             ex_flux_t(is:ie), ex_flux_tr(is:ie,isphum), ex_flux_lw(is:ie), ex_flux_u(is:ie), ex_flux_v(is:ie),         &
             ex_cd_m(is:ie),   ex_cd_t(is:ie), ex_cd_q(is:ie),                                    &
             ex_wind(is:ie),   ex_u_star(is:ie), ex_b_star(is:ie), ex_q_star(is:ie),                     &
-            ex_thv_atm(is:ie),   ex_thv_surf(is:ie),                                             &  ! ZNT
+            ex_thv_atm(is:ie),   ex_thv_surf(is:ie),                                             &
             ex_dhdt_surf(is:ie), ex_dedt_surf(is:ie), ex_dfdtr_surf(is:ie,isphum),  ex_drdt_surf(is:ie),        &
             ex_dhdt_atm(is:ie),  ex_dfdtr_atm(is:ie,isphum),  ex_dtaudu_atm(is:ie), ex_dtaudv_atm(is:ie),       &
             dt,                                                             &
@@ -1175,7 +1175,7 @@ contains
             ex_flux_t, ex_flux_tr(:,isphum), ex_flux_lw, ex_flux_u, ex_flux_v,         &
             ex_cd_m,   ex_cd_t, ex_cd_q,                                               &
             ex_wind,   ex_u_star, ex_b_star, ex_q_star,                                &
-            ex_thv_atm, ex_thv_surf,                                                   &   ! ZNT
+            ex_thv_atm, ex_thv_surf,                                                   &
             ex_dhdt_surf, ex_dedt_surf, ex_dfdtr_surf(:,isphum),  ex_drdt_surf,        &
             ex_dhdt_atm,  ex_dfdtr_atm(:,isphum),  ex_dtaudu_atm, ex_dtaudv_atm,       &
             dt,                                                                        &
@@ -1408,12 +1408,12 @@ contains
     call fms_xgrid_get_from_xgrid (Land_Ice_Atmos_Boundary%v_ref,     'ATM', ex_ref_v     , xmap_sfc, complete=.true.) !bqx
 
 #ifndef use_AM3_physics
-    call fms_xgrid_get_from_xgrid (Land_Ice_Atmos_Boundary%shflx,     'ATM', ex_flux_t    , xmap_sfc) !miz; ZNT 04/29/2020
-    call fms_xgrid_get_from_xgrid (Land_Ice_Atmos_Boundary%lhflx,     'ATM', ex_flux_tr(:,isphum), xmap_sfc)!miz; ZNT 04/29/2020
+    call fms_xgrid_get_from_xgrid (Land_Ice_Atmos_Boundary%shflx,     'ATM', ex_flux_t    , xmap_sfc)
+    call fms_xgrid_get_from_xgrid (Land_Ice_Atmos_Boundary%lhflx,     'ATM', ex_flux_tr(:,isphum), xmap_sfc)
 #endif
-    call fms_xgrid_get_from_xgrid (Land_Ice_Atmos_Boundary%wind,      'ATM', ex_wind      , xmap_sfc) ! ZNT 04/29/2020
-    call fms_xgrid_get_from_xgrid (Land_Ice_Atmos_Boundary%thv_atm,   'ATM', ex_thv_atm   , xmap_sfc) ! ZNT 05/03/2020
-    call fms_xgrid_get_from_xgrid (Land_Ice_Atmos_Boundary%thv_surf,  'ATM', ex_thv_surf  , xmap_sfc) ! ZNT 05/03/2020
+    call fms_xgrid_get_from_xgrid (Land_Ice_Atmos_Boundary%wind,      'ATM', ex_wind      , xmap_sfc)
+    call fms_xgrid_get_from_xgrid (Land_Ice_Atmos_Boundary%thv_atm,   'ATM', ex_thv_atm   , xmap_sfc)
+    call fms_xgrid_get_from_xgrid (Land_Ice_Atmos_Boundary%thv_surf,  'ATM', ex_thv_surf  , xmap_sfc)
 
 #ifdef use_AM3_physics
     if (do_forecast) then
@@ -1601,7 +1601,7 @@ contains
     !------- moisture scale -----------
     used = fms_diag_send_data ( id_q_star, Land_Ice_Atmos_Boundary%q_star, Time )
 
-    !------- ZNT: surf and atm virtual potential temperature -----------
+    !------- surf and atm virtual potential temperature -----------
     used = fms_diag_send_data ( id_thv_atm,  Land_Ice_Atmos_Boundary%thv_atm,  Time )
     used = fms_diag_send_data ( id_thv_surf, Land_Ice_Atmos_Boundary%thv_surf, Time )
 
@@ -3457,11 +3457,11 @@ contains
          fms_diag_register_diag_field ( mod_name, 'q_star',     atmos_axes, Time, &
          'moisture scale',      'kg water/kg air'   )
 
-    id_thv_atm = &   ! ZNT
+    id_thv_atm = &
          fms_diag_register_diag_field ( mod_name, 'thv_atm', atmos_axes, Time, &
          'surface air virtual potential temperature', 'K')
 
-    id_thv_surf = &  ! ZNT
+    id_thv_surf = &
          fms_diag_register_diag_field ( mod_name, 'thv_surf', atmos_axes, Time, &
          'surface virtual potential temperature', 'K')
 

--- a/shared/surface_flux.F90
+++ b/shared/surface_flux.F90
@@ -210,6 +210,7 @@ subroutine surface_flux_1d (                                           &
      flux_t, flux_q, flux_r, flux_u, flux_v,                           &
      cd_m,      cd_t,       cd_q,                                      &
      w_atm,     u_star,     b_star,     q_star,                        &
+     thv_atm,   thv_surf,                                              &  ! ZNT 05/03/2020
      dhdt_surf, dedt_surf,  dedq_surf,  drdt_surf,                     &
      dhdt_atm,  dedq_atm,   dtaudu_atm, dtaudv_atm,                    &
      dt,        land,      seawater,     avail  )
@@ -250,6 +251,8 @@ subroutine surface_flux_1d (                                           &
                                      u_star, & !< Turbulent velocity scale
                                      b_star, & !< Turbulent buoyant scale
                                      q_star, & !< Turbulent moisture scale
+                                     thv_atm, &   ! ZNT 05/03/2020
+                                     thv_surf, &  ! ZNT 05/03/2020
                                      cd_m, & !< Momentum exchange coefficient
                                      cd_t, & ! Heat exchange coefficient
                                      cd_q !< Moisture exchange coefficient
@@ -262,7 +265,7 @@ subroutine surface_flux_1d (                                           &
 
   ! ---- local vars ----------------------------------------------------------
   real, dimension(size(t_atm(:))) ::                          &
-       thv_atm,  th_atm,   tv_atm,    thv_surf,            &
+       th_atm,   tv_atm,   &  ! ZNT 05/03/2020: removed thv_atm and thv_surf
        e_sat,    e_sat1,   q_sat,     q_sat1,    p_ratio,  &
        t_surf0,  t_surf1,  u_dif,     v_dif,               &
        rho_drag, drag_t,   drag_m,    drag_q,    rho,      &
@@ -448,6 +451,8 @@ subroutine surface_flux_1d (                                           &
      q_star     = 0.0
      q_surf     = 0.0
      w_atm      = 0.0
+     thv_atm    = 0.0 ! ZNT 05/03/2020
+     thv_surf   = 0.0 ! ZNT 05/03/2020
   endwhere
 
   ! calculate d(stress component)/d(atmos wind component)
@@ -477,6 +482,7 @@ subroutine surface_flux_0d (                                                 &
      flux_t_0,    flux_q_0,     flux_r_0,    flux_u_0,  flux_v_0,            &
      cd_m_0,      cd_t_0,       cd_q_0,                                      &
      w_atm_0,     u_star_0,     b_star_0,     q_star_0,                      &
+     thv_atm_0,   thv_surf_0,                                                &  ! ZNT 05/03/2020
      dhdt_surf_0, dedt_surf_0,  dedq_surf_0,  drdt_surf_0,                   &
      dhdt_atm_0,  dedq_atm_0,   dtaudu_atm_0, dtaudv_atm_0,                  &
      dt,          land_0,       seawater_0,  avail_0  )
@@ -518,6 +524,8 @@ subroutine surface_flux_0d (                                                 &
                        u_star_0, & !< Turbulent velocity scale
                        b_star_0, & !< Turbulent buoyant scale
                        q_star_0, & !< Turbulent moisture scale
+                       thv_atm_0, &   ! ZNT 05/03/2020
+                       thv_surf_0, &  ! ZNT 05/03/2020
                        cd_m_0, & !< Momentum exchange coefficient
                        cd_t_0, & ! Heat exchange coefficient
                        cd_q_0 !< Moisture exchange coefficient
@@ -536,6 +544,7 @@ subroutine surface_flux_0d (                                                 &
        dhdt_surf, dedt_surf,  dedq_surf, drdt_surf,          &
        dhdt_atm,  dedq_atm,   dtaudu_atm,dtaudv_atm,         &
        w_atm,     u_star,     b_star,    q_star,             &
+       thv_atm,   thv_surf, &  ! ZNT 05/03/2020
        cd_m,      cd_t,       cd_q
   real, dimension(1) :: q_surf
 
@@ -571,6 +580,7 @@ subroutine surface_flux_0d (                                                 &
        flux_t, flux_q, flux_r, flux_u, flux_v,                           &
        cd_m,      cd_t,       cd_q,                                      &
        w_atm,     u_star,     b_star,     q_star,                        &
+       thv_atm,   thv_surf,                                              &  ! ZNT 05/03/2020
        dhdt_surf, dedt_surf,  dedq_surf,  drdt_surf,                     &
        dhdt_atm,  dedq_atm,   dtaudu_atm, dtaudv_atm,                    &
        dt,        land,      seawater, avail  )
@@ -593,6 +603,8 @@ subroutine surface_flux_0d (                                                 &
   b_star_0     = b_star(1)
   q_star_0     = q_star(1)
   q_surf_0     = q_surf(1)
+  thv_atm_0    = thv_atm(1)   ! ZNT 05/03/2020
+  thv_surf_0   = thv_surf(1)  ! ZNT 05/03/2020
   cd_m_0       = cd_m(1)
   cd_t_0       = cd_t(1)
   cd_q_0       = cd_q(1)
@@ -607,6 +619,7 @@ subroutine surface_flux_2d (                                           &
      flux_t,    flux_q,     flux_r,    flux_u,    flux_v,              &
      cd_m,      cd_t,       cd_q,                                      &
      w_atm,     u_star,     b_star,     q_star,                        &
+     thv_atm,   thv_surf,                                              &  ! ZNT 05/03/2020
      dhdt_surf, dedt_surf,  dedq_surf,  drdt_surf,                     &
      dhdt_atm,  dedq_atm,   dtaudu_atm, dtaudv_atm,                    &
      dt,        land,       seawater,  avail  )
@@ -648,6 +661,8 @@ subroutine surface_flux_2d (                                           &
                                        u_star, & !< Turbulent velocity scale
                                        b_star, & !< Turbulent buoyant scale
                                        q_star, & !< Turbulent moisture scale
+                                       thv_atm, &   ! ZNT 05/03/2020
+                                       thv_surf, &  ! ZNT 05/03/2020
                                        cd_m, & !< Momentum exchange coefficient
                                        cd_t, & ! Heat exchange coefficient
                                        cd_q !< Moisture exchange coefficient
@@ -666,6 +681,7 @@ subroutine surface_flux_2d (                                           &
           flux_t(:,j),    flux_q(:,j),     flux_r(:,j),    flux_u(:,j),    flux_v(:,j),                   &
           cd_m(:,j),      cd_t(:,j),       cd_q(:,j),                                                     &
           w_atm(:,j),     u_star(:,j),     b_star(:,j),     q_star(:,j),                                  &
+          thv_atm(:,j),   thv_surf(:,j),                                                                  &  ! ZNT 05/03/2020
           dhdt_surf(:,j), dedt_surf(:,j),  dedq_surf(:,j),  drdt_surf(:,j),                               &
           dhdt_atm(:,j),  dedq_atm(:,j),   dtaudu_atm(:,j), dtaudv_atm(:,j),                              &
           dt,             land(:,j),       seawater(:,j),  avail(:,j)  )

--- a/shared/surface_flux.F90
+++ b/shared/surface_flux.F90
@@ -210,7 +210,7 @@ subroutine surface_flux_1d (                                           &
      flux_t, flux_q, flux_r, flux_u, flux_v,                           &
      cd_m,      cd_t,       cd_q,                                      &
      w_atm,     u_star,     b_star,     q_star,                        &
-     thv_atm,   thv_surf,                                              &  ! ZNT 05/03/2020
+     thv_atm,   thv_surf,                                              &
      dhdt_surf, dedt_surf,  dedq_surf,  drdt_surf,                     &
      dhdt_atm,  dedq_atm,   dtaudu_atm, dtaudv_atm,                    &
      dt,        land,      seawater,     avail  )
@@ -251,8 +251,8 @@ subroutine surface_flux_1d (                                           &
                                      u_star, & !< Turbulent velocity scale
                                      b_star, & !< Turbulent buoyant scale
                                      q_star, & !< Turbulent moisture scale
-                                     thv_atm, &   ! ZNT 05/03/2020
-                                     thv_surf, &  ! ZNT 05/03/2020
+                                     thv_atm, &   ! Surface air theta_v
+                                     thv_surf, &  ! Surface theta_v
                                      cd_m, & !< Momentum exchange coefficient
                                      cd_t, & ! Heat exchange coefficient
                                      cd_q !< Moisture exchange coefficient
@@ -265,7 +265,7 @@ subroutine surface_flux_1d (                                           &
 
   ! ---- local vars ----------------------------------------------------------
   real, dimension(size(t_atm(:))) ::                          &
-       th_atm,   tv_atm,   &  ! ZNT 05/03/2020: removed thv_atm and thv_surf
+       th_atm,   tv_atm,   &  ! thv_atm and thv_surf are moved to output
        e_sat,    e_sat1,   q_sat,     q_sat1,    p_ratio,  &
        t_surf0,  t_surf1,  u_dif,     v_dif,               &
        rho_drag, drag_t,   drag_m,    drag_q,    rho,      &
@@ -451,8 +451,8 @@ subroutine surface_flux_1d (                                           &
      q_star     = 0.0
      q_surf     = 0.0
      w_atm      = 0.0
-     thv_atm    = 0.0 ! ZNT 05/03/2020
-     thv_surf   = 0.0 ! ZNT 05/03/2020
+     thv_atm    = 0.0
+     thv_surf   = 0.0
   endwhere
 
   ! calculate d(stress component)/d(atmos wind component)
@@ -482,7 +482,7 @@ subroutine surface_flux_0d (                                                 &
      flux_t_0,    flux_q_0,     flux_r_0,    flux_u_0,  flux_v_0,            &
      cd_m_0,      cd_t_0,       cd_q_0,                                      &
      w_atm_0,     u_star_0,     b_star_0,     q_star_0,                      &
-     thv_atm_0,   thv_surf_0,                                                &  ! ZNT 05/03/2020
+     thv_atm_0,   thv_surf_0,                                                &
      dhdt_surf_0, dedt_surf_0,  dedq_surf_0,  drdt_surf_0,                   &
      dhdt_atm_0,  dedq_atm_0,   dtaudu_atm_0, dtaudv_atm_0,                  &
      dt,          land_0,       seawater_0,  avail_0  )
@@ -524,8 +524,8 @@ subroutine surface_flux_0d (                                                 &
                        u_star_0, & !< Turbulent velocity scale
                        b_star_0, & !< Turbulent buoyant scale
                        q_star_0, & !< Turbulent moisture scale
-                       thv_atm_0, &   ! ZNT 05/03/2020
-                       thv_surf_0, &  ! ZNT 05/03/2020
+                       thv_atm_0, &   ! Surface air theta_v
+                       thv_surf_0, &  ! Surface theta_v
                        cd_m_0, & !< Momentum exchange coefficient
                        cd_t_0, & ! Heat exchange coefficient
                        cd_q_0 !< Moisture exchange coefficient
@@ -544,7 +544,7 @@ subroutine surface_flux_0d (                                                 &
        dhdt_surf, dedt_surf,  dedq_surf, drdt_surf,          &
        dhdt_atm,  dedq_atm,   dtaudu_atm,dtaudv_atm,         &
        w_atm,     u_star,     b_star,    q_star,             &
-       thv_atm,   thv_surf, &  ! ZNT 05/03/2020
+       thv_atm,   thv_surf, &
        cd_m,      cd_t,       cd_q
   real, dimension(1) :: q_surf
 
@@ -580,7 +580,7 @@ subroutine surface_flux_0d (                                                 &
        flux_t, flux_q, flux_r, flux_u, flux_v,                           &
        cd_m,      cd_t,       cd_q,                                      &
        w_atm,     u_star,     b_star,     q_star,                        &
-       thv_atm,   thv_surf,                                              &  ! ZNT 05/03/2020
+       thv_atm,   thv_surf,                                              &
        dhdt_surf, dedt_surf,  dedq_surf,  drdt_surf,                     &
        dhdt_atm,  dedq_atm,   dtaudu_atm, dtaudv_atm,                    &
        dt,        land,      seawater, avail  )
@@ -603,8 +603,8 @@ subroutine surface_flux_0d (                                                 &
   b_star_0     = b_star(1)
   q_star_0     = q_star(1)
   q_surf_0     = q_surf(1)
-  thv_atm_0    = thv_atm(1)   ! ZNT 05/03/2020
-  thv_surf_0   = thv_surf(1)  ! ZNT 05/03/2020
+  thv_atm_0    = thv_atm(1)
+  thv_surf_0   = thv_surf(1)
   cd_m_0       = cd_m(1)
   cd_t_0       = cd_t(1)
   cd_q_0       = cd_q(1)
@@ -619,7 +619,7 @@ subroutine surface_flux_2d (                                           &
      flux_t,    flux_q,     flux_r,    flux_u,    flux_v,              &
      cd_m,      cd_t,       cd_q,                                      &
      w_atm,     u_star,     b_star,     q_star,                        &
-     thv_atm,   thv_surf,                                              &  ! ZNT 05/03/2020
+     thv_atm,   thv_surf,                                              &
      dhdt_surf, dedt_surf,  dedq_surf,  drdt_surf,                     &
      dhdt_atm,  dedq_atm,   dtaudu_atm, dtaudv_atm,                    &
      dt,        land,       seawater,  avail  )
@@ -661,8 +661,8 @@ subroutine surface_flux_2d (                                           &
                                        u_star, & !< Turbulent velocity scale
                                        b_star, & !< Turbulent buoyant scale
                                        q_star, & !< Turbulent moisture scale
-                                       thv_atm, &   ! ZNT 05/03/2020
-                                       thv_surf, &  ! ZNT 05/03/2020
+                                       thv_atm, &   ! Surface air theta_v
+                                       thv_surf, &  ! Surface theta_v
                                        cd_m, & !< Momentum exchange coefficient
                                        cd_t, & ! Heat exchange coefficient
                                        cd_q !< Moisture exchange coefficient
@@ -681,7 +681,7 @@ subroutine surface_flux_2d (                                           &
           flux_t(:,j),    flux_q(:,j),     flux_r(:,j),    flux_u(:,j),    flux_v(:,j),                   &
           cd_m(:,j),      cd_t(:,j),       cd_q(:,j),                                                     &
           w_atm(:,j),     u_star(:,j),     b_star(:,j),     q_star(:,j),                                  &
-          thv_atm(:,j),   thv_surf(:,j),                                                                  &  ! ZNT 05/03/2020
+          thv_atm(:,j),   thv_surf(:,j),                                                                  &
           dhdt_surf(:,j), dedt_surf(:,j),  dedq_surf(:,j),  drdt_surf(:,j),                               &
           dhdt_atm(:,j),  dedq_atm(:,j),   dtaudu_atm(:,j), dtaudv_atm(:,j),                              &
           dt,             land(:,j),       seawater(:,j),  avail(:,j)  )

--- a/simple/flux_exchange.F90
+++ b/simple/flux_exchange.F90
@@ -59,7 +59,7 @@ integer :: id_drag_moist,  id_drag_heat,  id_drag_mom,              &
            id_u_star, id_b_star, id_q_star, id_u_flux, id_v_flux,   &
            id_t_surf, id_t_flux, id_q_flux, id_r_flux,              &
            id_t_atm,  id_u_atm,  id_v_atm,  id_wind,                &
-           id_thv_atm, id_thv_surf,                                 & ! ZNT
+           id_thv_atm, id_thv_surf,                                 &
            id_t_ref,  id_rh_ref, id_u_ref,  id_v_ref,  id_q_ref,    &
            id_del_h,  id_del_m,  id_del_q, id_albedo,  id_gust,     &
            id_t_ca,   id_q_surf, id_q_atm, id_z_atm, id_p_atm,      &
@@ -804,9 +804,9 @@ subroutine flux_up_to_atmos (Time, Land, Ice, Boundary )
         allocate( land_ice_atmos_boundary%shflx(is:ie,js:je) )!miz
         allocate( land_ice_atmos_boundary%lhflx(is:ie,js:je) )!miz
 #endif
-   allocate( land_ice_atmos_boundary%wind(is:ie,js:je) )    !ZNT
-   allocate( land_ice_atmos_boundary%thv_atm(is:ie,js:je) ) !ZNT
-   allocate( land_ice_atmos_boundary%thv_surf(is:ie,js:je) )!ZNT
+   allocate( land_ice_atmos_boundary%wind(is:ie,js:je) )
+   allocate( land_ice_atmos_boundary%thv_atm(is:ie,js:je) )
+   allocate( land_ice_atmos_boundary%thv_surf(is:ie,js:je) )
    allocate( land_ice_atmos_boundary%rough_mom(is:ie,js:je) )
    allocate( land_ice_atmos_boundary%frac_open_sea(is:ie,js:je) )
 
@@ -834,9 +834,9 @@ subroutine flux_up_to_atmos (Time, Land, Ice, Boundary )
    land_ice_atmos_boundary%shflx=0.0
    land_ice_atmos_boundary%lhflx=0.0
 #endif
-   land_ice_atmos_boundary%wind=0.0     ! ZNT
-   land_ice_atmos_boundary%thv_atm=0.0  ! ZNT
-   land_ice_atmos_boundary%thv_surf=0.0 ! ZNT
+   land_ice_atmos_boundary%wind=0.0
+   land_ice_atmos_boundary%thv_atm=0.0
+   land_ice_atmos_boundary%thv_surf=0.0
    land_ice_atmos_boundary%rough_mom=0.01
    land_ice_atmos_boundary%frac_open_sea=0.0
 
@@ -958,11 +958,11 @@ subroutine diag_field_init ( Time, atmos_axes )
    fms_diag_register_diag_field ( mod_name, 'q_star',     atmos_axes, Time, &
        'moisture scale',      'kg water/kg air'   )
 
-   id_thv_atm = &   ! ZNT
+   id_thv_atm = &
    fms_diag_register_diag_field ( mod_name, 'thv_atm', atmos_axes, Time, &
        'surface air virtual potential temperature', 'K')
 
-   id_thv_surf = &  ! ZNT
+   id_thv_surf = &
    fms_diag_register_diag_field ( mod_name, 'thv_surf', atmos_axes, Time, &
        'surface virtual potential temperature', 'K')
 
@@ -1183,7 +1183,7 @@ subroutine surface_flux_2d (                                           &
      flux_t,    flux_q,     flux_r,    flux_u,    flux_v,              &
      cd_m,      cd_t,       cd_q,                                      &
      w_atm,     u_star,     b_star,     q_star,                        &
-     thv_atm,   thv_surf,                                              &  ! ZNT 05/03/2020
+     thv_atm,   thv_surf,                                              &
      dhdt_surf, dedt_surf,  dedq_surf,  drdt_surf,                     &
      dhdt_atm,  dedq_atm,   dtaudu_atm, dtaudv_atm,                    &
      dt,        land,       seawater,  avail  )
@@ -1201,7 +1201,7 @@ subroutine surface_flux_2d (                                           &
        dhdt_surf, dedt_surf,  dedq_surf, drdt_surf,          &
        dhdt_atm,  dedq_atm,   dtaudu_atm,dtaudv_atm,         &
        w_atm,     u_star,     b_star,    q_star,             &
-       thv_atm,   thv_surf,                                  &  ! ZNT 05/03/2020
+       thv_atm,   thv_surf,                                  &
        cd_m,      cd_t,       cd_q
   real, intent(inout), dimension(:,:) :: q_surf
   real, intent(in) :: dt
@@ -1218,7 +1218,7 @@ subroutine surface_flux_2d (                                           &
           flux_t(:,j),    flux_q(:,j),     flux_r(:,j),    flux_u(:,j),    flux_v(:,j),             &
           cd_m(:,j),      cd_t(:,j),       cd_q(:,j),                                               &
           w_atm(:,j),     u_star(:,j),     b_star(:,j),     q_star(:,j),                            &
-          thv_atm(:,j),   thv_surf(:,j),                                                            &  ! ZNT 05/03/2020
+          thv_atm(:,j),   thv_surf(:,j),                                                            &
           dhdt_surf(:,j), dedt_surf(:,j),  dedq_surf(:,j),  drdt_surf(:,j),                         &
           dhdt_atm(:,j),  dedq_atm(:,j),   dtaudu_atm(:,j), dtaudv_atm(:,j),                        &
           dt,             land(:,j),       seawater(:,j),  avail(:,j)  )


### PR DESCRIPTION
This PR is linked to issue #92. 

A new boundary layer scheme (NCEP TKE-based eddy-diffusivity mass-flux scheme) is being implemented in the prototype-AM5 model, and it requires five additional surface variables (shflx, lhflx, wind, thv_atm, and thv_surf) as inputs. Thus, I would like to add a few lines in the surface coupler (full/atm_land_ice_flux_exchange.F90 and shared/surface_flux.F90) to pass these variables into the atmospheric model. My branch contains the proposed changes, and the model results are unchanged with these changes.