### PR TITLE
Keyword `DATA` FMS update

### DIFF
--- a/full/atm_land_ice_flux_exchange.F90
+++ b/full/atm_land_ice_flux_exchange.F90
@@ -2621,7 +2621,7 @@ contains
     call fms_xgrid_stock_move( &
          & FROM = fms_stock_constants_atm_stock(ISTOCK_WATER), &
          & TO   = fms_stock_constants_ice_stock(ISTOCK_WATER), &
-         & stock_data2d = (Ice_boundary%lprec + Ice_boundary%fprec), &
+         & stock_data3d = (Ice_boundary%lprec + Ice_boundary%fprec), &
          & grid_index=X1_GRID_ICE, &
          & xmap=xmap_sfc, &
          & delta_t=Dt_atm, &
@@ -2632,7 +2632,7 @@ contains
     call fms_xgrid_stock_move( &
          & FROM = fms_stock_constants_atm_stock(ISTOCK_HEAT), &
          & TO   = fms_stock_constants_ice_stock(ISTOCK_HEAT), &
-         & stock_data2d = (-Ice_boundary%t_flux + Ice_boundary%lw_flux - Ice_boundary%fprec*HLF + Ice_boundary%sw_flux_vis_dir + &
+         & stock_data3d = (-Ice_boundary%t_flux + Ice_boundary%lw_flux - Ice_boundary%fprec*HLF + Ice_boundary%sw_flux_vis_dir + &
          Ice_boundary%sw_flux_vis_dif + Ice_boundary%sw_flux_nir_dir + Ice_boundary%sw_flux_nir_dif), &
          & grid_index=X1_GRID_ICE, &
          & xmap=xmap_sfc, &

--- a/full/atm_land_ice_flux_exchange.F90
+++ b/full/atm_land_ice_flux_exchange.F90
@@ -2577,7 +2577,7 @@ contains
     call fms_xgrid_stock_move_ug( &
          & FROM = fms_stock_constants_atm_stock(ISTOCK_WATER),  &
          & TO   = fms_stock_constants_lnd_stock(ISTOCK_WATER), &
-         & DATA = (Land_boundary%lprec + Land_boundary%fprec), &
+         & stock_ug_data3d = (Land_boundary%lprec + Land_boundary%fprec), &
          & grid_index=X1_GRID_LND, &
          & xmap=xmap_sfc, &
          & delta_t=Dt_atm, &
@@ -2588,7 +2588,7 @@ contains
     call fms_xgrid_stock_move_ug( &
          & FROM = fms_stock_constants_atm_stock(ISTOCK_HEAT),  &
          & TO   = fms_stock_constants_lnd_stock(ISTOCK_HEAT), &
-         & DATA = (-Land_boundary%t_flux + Land_boundary%lw_flux +  Land_boundary%sw_flux - Land_boundary%fprec*HLF), &
+         & stock_ug_data3d = (-Land_boundary%t_flux + Land_boundary%lw_flux +  Land_boundary%sw_flux - Land_boundary%fprec*HLF), &
          & grid_index=X1_GRID_LND, &
          & xmap=xmap_sfc, &
          & delta_t=Dt_atm, &
@@ -2598,7 +2598,7 @@ contains
     call fms_xgrid_stock_move( &
          & FROM = fms_stock_constants_atm_stock(ISTOCK_WATER),  &
          & TO   = fms_stock_constants_lnd_stock(ISTOCK_WATER), &
-         & DATA = (Land_boundary%lprec + Land_boundary%fprec), &
+         & stock_data3d = (Land_boundary%lprec + Land_boundary%fprec), &
          & grid_index=X1_GRID_LND, &
          & xmap=xmap_sfc, &
          & delta_t=Dt_atm, &
@@ -2609,7 +2609,7 @@ contains
     call fms_xgrid_stock_move( &
          & FROM = fms_stock_constants_atm_stock(ISTOCK_HEAT),  &
          & TO   = fms_stock_constants_lnd_stock(ISTOCK_HEAT), &
-         & DATA = (-Land_boundary%t_flux + Land_boundary%lw_flux +  Land_boundary%sw_flux - Land_boundary%fprec*HLF), &
+         & stock_data3d = (-Land_boundary%t_flux + Land_boundary%lw_flux +  Land_boundary%sw_flux - Land_boundary%fprec*HLF), &
          & grid_index=X1_GRID_LND, &
          & xmap=xmap_sfc, &
          & delta_t=Dt_atm, &
@@ -2621,7 +2621,7 @@ contains
     call fms_xgrid_stock_move( &
          & FROM = fms_stock_constants_atm_stock(ISTOCK_WATER), &
          & TO   = fms_stock_constants_ice_stock(ISTOCK_WATER), &
-         & DATA = (Ice_boundary%lprec + Ice_boundary%fprec), &
+         & stock_data2d = (Ice_boundary%lprec + Ice_boundary%fprec), &
          & grid_index=X1_GRID_ICE, &
          & xmap=xmap_sfc, &
          & delta_t=Dt_atm, &
@@ -2632,7 +2632,7 @@ contains
     call fms_xgrid_stock_move( &
          & FROM = fms_stock_constants_atm_stock(ISTOCK_HEAT), &
          & TO   = fms_stock_constants_ice_stock(ISTOCK_HEAT), &
-         & DATA = (-Ice_boundary%t_flux + Ice_boundary%lw_flux - Ice_boundary%fprec*HLF + Ice_boundary%sw_flux_vis_dir + &
+         & stock_data2d = (-Ice_boundary%t_flux + Ice_boundary%lw_flux - Ice_boundary%fprec*HLF + Ice_boundary%sw_flux_vis_dir + &
          Ice_boundary%sw_flux_vis_dif + Ice_boundary%sw_flux_nir_dir + Ice_boundary%sw_flux_nir_dif), &
          & grid_index=X1_GRID_ICE, &
          & xmap=xmap_sfc, &
@@ -3097,7 +3097,7 @@ contains
     call fms_xgrid_stock_move_ug( &
          & TO   = fms_stock_constants_atm_stock(ISTOCK_WATER), &
          & FROM = fms_stock_constants_lnd_stock(ISTOCK_WATER), &
-         & DATA = data_lnd, &
+         & stock_ug_data3d = data_lnd, &
          & grid_index=X1_GRID_LND, &
          & xmap=xmap_sfc, &
          & delta_t=Dt_atm, &
@@ -3108,7 +3108,7 @@ contains
     call fms_xgrid_stock_move_ug( &
          & TO   = fms_stock_constants_atm_stock(ISTOCK_HEAT), &
          & FROM = fms_stock_constants_lnd_stock(ISTOCK_HEAT), &
-         & DATA = data_lnd * HLV, &
+         & stock_ug_data3d = data_lnd * HLV, &
          & grid_index=X1_GRID_LND, &
          & xmap=xmap_sfc, &
          & delta_t=Dt_atm, &
@@ -3123,7 +3123,7 @@ contains
     call fms_xgrid_stock_move( &
          & TO   = fms_stock_constants_atm_stock(ISTOCK_WATER), &
          & FROM = fms_stock_constants_lnd_stock(ISTOCK_WATER), &
-         & DATA = data_lnd, &
+         & stock_data3d = data_lnd, &
          & grid_index=X1_GRID_LND, &
          & xmap=xmap_sfc, &
          & delta_t=Dt_atm, &
@@ -3134,7 +3134,7 @@ contains
     call fms_xgrid_stock_move( &
          & TO   = fms_stock_constants_atm_stock(ISTOCK_HEAT), &
          & FROM = fms_stock_constants_lnd_stock(ISTOCK_HEAT), &
-         & DATA = data_lnd * HLV, &
+         & stock_data3d = data_lnd * HLV, &
          & grid_index=X1_GRID_LND, &
          & xmap=xmap_sfc, &
          & delta_t=Dt_atm, &
@@ -3148,7 +3148,7 @@ contains
     call fms_xgrid_stock_move( &
          & TO   = fms_stock_constants_atm_stock(ISTOCK_WATER), &
          & FROM = fms_stock_constants_ice_stock(ISTOCK_WATER), &
-         & DATA = data_ice, &
+         & stock_data3d = data_ice, &
          & grid_index=X1_GRID_ICE, &
          & xmap=xmap_sfc, &
          & delta_t=Dt_atm, &
@@ -3159,7 +3159,7 @@ contains
     call fms_xgrid_stock_move( &
          & TO   = fms_stock_constants_atm_stock(ISTOCK_HEAT), &
          & FROM = fms_stock_constants_ice_stock(ISTOCK_HEAT), &
-         & DATA = data_ice * HLV, &
+         & stock_data3d = data_ice * HLV, &
          & grid_index=X1_GRID_ICE, &
          & xmap=xmap_sfc, &
          & delta_t=Dt_atm, &

--- a/full/land_ice_flux_exchange.F90
+++ b/full/land_ice_flux_exchange.F90
@@ -142,7 +142,7 @@ contains
        ice_buf(:,:,1) = Land_Ice_Boundary%runoff + Land_Ice_Boundary%calving
        call fms_xgrid_stock_move(from=fms_stock_constants_lnd_stock(ISTOCK_WATER), to=fms_stock_constants_ice_stock(ISTOCK_WATER), &
             & grid_index=X2_GRID_ICE, &
-            & data=ice_buf, &
+            & stock_data3d=ice_buf, &
             & xmap=xmap_runoff, &
             & delta_t=Dt_cpl, &
             & from_side=ISTOCK_SIDE, to_side=ISTOCK_SIDE, &


### PR DESCRIPTION
Subroutines `fms_xgrid_stock_move` and `fms_xgrid_stock_move_ug` have had their internal variable, `DATA`, changed in the FMS `data` keyword replacement. `DATA` is changed to `stock_data3d`, `stock_data2d`, or `stock_ug_data3d` depending on which variant of the `stock_move` subroutine is used (`stock_move_3d`, `stock_move_2d`, `stock_move_ug_3d`, respectively). When calling these subroutines, the internal variable is referenced accordingly, reflecting the changes in the FMS xgrid_mod.