### PR TITLE
Add a diag_send_complete call

### DIFF
--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -1070,6 +1070,7 @@ program coupler_main
       ! does not modify either Ocean or Ice_ocean_boundary
       call flux_ocean_from_ice_stocks(Ocean_state, Ocean, Ice_ocean_boundary)
 
+      call fms_diag_send_complete(Time_step_cpld)
       Time_ocean = Time_ocean +  Time_step_cpld
       Time = Time_ocean
 


### PR DESCRIPTION
Add a diag_send_complete call. This is needed for the new diag manager. It is backwards compatible with the old diag manager.  