### PR TITLE
Enable running SHiELD with a Gregorian calendar

### DIFF
--- a/SHiELD/coupler_main.F90
+++ b/SHiELD/coupler_main.F90
@@ -249,6 +249,8 @@ contains
 
 !----- override calendar type with namelist value -----
       select case( fms_mpp_uppercase(trim(calendar)) )
+      case( 'GREGORIAN' )
+          calendar_type = GREGORIAN
       case( 'JULIAN' )
           calendar_type = JULIAN
       case( 'NOLEAP' )
@@ -259,7 +261,7 @@ contains
           calendar_type = NO_CALENDAR
       case default
           call fms_mpp_error ( FATAL, 'COUPLER_MAIN: coupler_nml entry calendar must '// &
-                                  'be one of JULIAN|NOLEAP|THIRTY_DAY|NO_CALENDAR.' )
+                                  'be one of GREGORIAN|JULIAN|NOLEAP|THIRTY_DAY|NO_CALENDAR.' )
       end select
 
     endif


### PR DESCRIPTION
This PR fixes #103 by adding `'GREGORIAN'` as an option in the select case statement for inferring the `calendar_type` in SHiELD's `coupler_main.F90`.  I tested this in a short simulation (including a restart) and things ran without a problem, so this indeed appears as simple as @bensonr suggested.

cc: @lharris4