### PR TITLE
add an option to obtain the cocurrent drag and heat transfer coeffients

### DIFF
--- a/shared/surface_flux.F90
+++ b/shared/surface_flux.F90
@@ -281,7 +281,7 @@ subroutine surface_flux_1d (                                           &
        q_atm,    q_surf0,  dw_atmdu,  dw_atmdv,  w_gust,   &
        zu,       zt,       zq
 
-  integer :: i, j, nbad
+  integer :: i, nbad
 
 
   if (.not. module_is_initialized) &

--- a/shared/surface_flux.F90
+++ b/shared/surface_flux.F90
@@ -176,7 +176,7 @@ logical :: ncar_ocean_flux_orig  = .false. !< Use NCAR climate model turbulent f
                                            !! heat.  This option is available for legacy purposes, and is not recommended for
                                            !! new experiments.
 logical :: ncar_ocean_flux_multilevel  = .false. !< Use NCAR climate model turbulent flux calculation described by Large and Yeager, allows for different reference height for wind, temp and spec. hum.
-logical :: do_iter_monin_obukhov       = .false. !< If .TRUE,  call monin obukhov funtions a couple of times to update 
+logical :: do_iter_monin_obukhov       = .false. !< If .TRUE,  call monin obukhov funtcions a couple of times to update 
                                                  !! rough_mom, rough_heat, rough_moist, cd, ch, b_star, u_star 
 logical :: use_u10_neutral             = .false. !< If .TRUE., use 10m neutral wind rather than the standard 10m wind 
                                                  !! to obtain rough_mom, rough_heat, rough_moist
@@ -185,7 +185,7 @@ real :: bulk_zt = 10.                      !< Reference height for atm temperatu
 real :: bulk_zq = 10.                      !< Reference height for atm humidity (meters)
 logical :: raoult_sat_vap        = .false. !< Reduce saturation vapor pressure to account for seawater
 logical :: do_simple             = .false.
-integer :: niter                 = 5       !< iteration times to call iter_monin_obukhov_ocean. Typically 3-5 times should converge
+integer :: niter_monin_obukhov   = 5       !< iteration times to call iter_monin_obukhov_ocean. Typically 3-5 times should converge
 !
 
 namelist /surface_flux_nml/ no_neg_q,                   &
@@ -205,7 +205,7 @@ namelist /surface_flux_nml/ no_neg_q,                   &
                             do_simple,                  &
                             do_iter_monin_obukhov,      &
                             use_u10_neutral,            &
-                            niter
+                            niter_monin_obukhov
 
 contains
 
@@ -1052,7 +1052,7 @@ subroutine iter_monin_obukhov_ocean (                      &
            rough_mom1, rough_heat1, rough_moist1
   integer i, j
 
-  do i = 1, niter                              
+  do i = 1, niter_monin_obukhov                             
    do j = 1, size(avail)
     if (avail(j) .and. seawater(j)) then
 

--- a/simple/flux_exchange.F90
+++ b/simple/flux_exchange.F90
@@ -1195,7 +1195,7 @@ subroutine surface_flux_2d (                                           &
        t_atm,     q_atm_in,   u_atm,     v_atm,              &
        p_atm,     z_atm,      t_ca,                          &
        p_surf,    t_surf,     u_surf,    v_surf,             &
-       rough_mom, rough_heat, rough_moist, rough_scale, gust
+       rough_scale, gust
   real, intent(out), dimension(:,:) :: &
        flux_t,    flux_q,     flux_r,    flux_u,  flux_v,    &
        dhdt_surf, dedt_surf,  dedq_surf, drdt_surf,          &
@@ -1203,7 +1203,8 @@ subroutine surface_flux_2d (                                           &
        w_atm,     u_star,     b_star,    q_star,             &
        thv_atm,   thv_surf,                                  &
        cd_m,      cd_t,       cd_q
-  real, intent(inout), dimension(:,:) :: q_surf
+  real, intent(inout), dimension(:,:) :: q_surf, rough_mom,  &
+       rough_heat, rough_moist 
   real, intent(in) :: dt
 
   ! ---- local vars -----------------------------------------------------------


### PR DESCRIPTION
For the current model setting, the ocean roughness for momentum, heat and moisture is input variables which are calculated based on the atmospheric condition at the previous time step. We add one option to update the ocean roughness by iterating the monin obukhov function so as to obtain concurrent roughness, drag and heat/moisture coefficients.