### PR TITLE
11 - update_land_model_fast to update_atmos_model_state

### DIFF
--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -340,7 +340,7 @@ program coupler_main
   implicit none
 
   !> model defined types.
-  !! Targets to pointers in coupler_chksum_obj
+  !! Targets to pointers in coupler_components_obj
   type (atmos_data_type), target :: Atm
   type  (land_data_type), target :: Land
   type   (ice_data_type), target :: Ice
@@ -372,8 +372,9 @@ program coupler_main
   type(FmsTime_type) :: Time_restart_current
   character(len=32) :: timestamp
 
-  type(coupler_clock_type) :: coupler_clocks
-  type(coupler_chksum_type) :: coupler_chksum_obj
+  type(coupler_clock_type)      :: coupler_clocks
+  type(coupler_components_type) :: coupler_components_obj
+  type(coupler_chksum_type)     :: coupler_chksum_obj
 
   integer :: outunit
   character(len=80) :: text
@@ -429,10 +430,11 @@ program coupler_main
   call coupler_init(Atm, Ocean, Land, Ice, Ocean_state, Atmos_land_boundary, Atmos_ice_boundary, &
     Ocean_ice_boundary, Ice_ocean_boundary, Land_ice_atmos_boundary, Land_ice_boundary,          &
     Ice_ocean_driver_CS, Ice_bc_restart, Ocn_bc_restart, ensemble_pelist, slow_ice_ocean_pelist, &
-    conc_nthreads, coupler_clocks, coupler_chksum_obj, Time_step_cpld, Time_step_atmos, Time_atmos, Time_ocean, &
-    num_cpld_calls, num_atmos_calls, Time, Time_start, Time_end, Time_restart, Time_restart_current)
+    conc_nthreads, coupler_clocks, coupler_components_obj, coupler_chksum_obj, &
+    Time_step_cpld, Time_step_atmos, Time_atmos, Time_ocean, num_cpld_calls,   &
+    num_atmos_calls, Time, Time_start, Time_end, Time_restart, Time_restart_current)
 
-  if (do_chksum) call coupler_chksum('coupler_init+', 0, coupler_chksum_obj)
+  if (do_chksum) call coupler_chksum_obj%coupler_chksum('coupler_init+', 0)
 
   call fms_mpp_set_current_pelist()
   call fms_mpp_clock_end(coupler_clocks%initialization) !end initialization
@@ -448,8 +450,8 @@ program coupler_main
   do nc = 1, num_cpld_calls
 
     if (do_chksum) then
-      call coupler_chksum('top_of_coupled_loop+', nc, coupler_chksum_obj)
-      call coupler_atmos_ice_land_ocean_chksum('MAIN_LOOP-', nc, coupler_chksum_obj)
+      call coupler_chksum_obj%coupler_chksum('top_of_coupled_loop+', nc)
+      call coupler_chksum_obj%coupler_atmos_ice_land_ocean_chksum('MAIN_LOOP-', nc)
     end if
 
     ! Calls to flux_ocean_to_ice and flux_ice_to_ocean are all PE communication
@@ -470,8 +472,8 @@ program coupler_main
     end if
 
     if (do_chksum) then
-      call coupler_chksum('flux_ocn2ice+', nc, coupler_chksum_obj)
-      call coupler_atmos_ice_land_ocean_chksum('flux_ocn2ice+', nc, coupler_chksum_obj)
+      call coupler_chksum_obj%coupler_chksum('flux_ocn2ice+', nc)
+      call coupler_chksum_obj%coupler_atmos_ice_land_ocean_chksum('flux_ocn2ice+', nc)
     end if
 
     ! needs to sit here rather than at the end of the coupler loop.
@@ -497,7 +499,7 @@ program coupler_main
 
       if (.NOT.(do_ice.and.Ice%pe) .OR. (ice_npes.NE.atmos_npes)) call fms_mpp_set_current_pelist(Atm%pelist)
 
-      if(do_chksum) call atmos_ice_land_chksum('set_ice_surface+', nc, coupler_chksum_obj)
+      if(do_chksum) call coupler_chksum_obj%atmos_ice_land_chksum('set_ice_surface+', nc)
 
       call fms_mpp_clock_begin(coupler_clocks%atm)
 
@@ -513,7 +515,7 @@ program coupler_main
         Time_atmos = Time_atmos + Time_step_atmos
         current_timestep = (nc-1)*num_atmos_calls+na
 
-        if (do_chksum) call atmos_ice_land_chksum('top_of_atmos_loop-', current_timestep, coupler_chksum_obj)
+        if (do_chksum) call coupler_chksum_obj%atmos_ice_land_chksum('top_of_atmos_loop-', current_timestep)
 
         if (do_atmos) call coupler_atmos_tracer_driver_gather_data(Atm, coupler_clocks)
 
@@ -551,8 +553,7 @@ program coupler_main
             call update_atmos_model_dynamics(Atm)
             call fms_mpp_clock_end(coupler_clocks%update_atmos_model_dynamics)
           endif
-          if (do_chksum) call atmos_ice_land_chksum('update_atmos_model_dynamics', (nc-1)*num_atmos_calls+na, &
-                                                    coupler_chksum_obj)
+          if (do_chksum) call coupler_chksum_obj%atmos_ice_land_chksum('update_atmos_model_dynamics', current_timestep)
           if (do_debug)  call fms_memutils_print_memuse_stats( 'update dyn')
 
           !      ---- SERIAL atmosphere radiation ----
@@ -561,8 +562,8 @@ program coupler_main
             call update_atmos_model_radiation( Land_ice_atmos_boundary, Atm )
             call fms_mpp_clock_end(coupler_clocks%serial_radiation)
           endif
-          if (do_chksum) call atmos_ice_land_chksum('update_atmos_model_radiation(ser)', (nc-1)*num_atmos_calls+na, &
-                                                    coupler_chksum_obj)
+          if (do_chksum) &
+              call coupler_chksum_obj%atmos_ice_land_chksum('update_atmos_model_radiation(ser)', current_timestep)
           if (do_debug)  call fms_memutils_print_memuse_stats( 'update serial rad')
 
           !      ---- atmosphere down ----
@@ -571,8 +572,7 @@ program coupler_main
             call update_atmos_model_down( Land_ice_atmos_boundary, Atm )
             call fms_mpp_clock_end(coupler_clocks%update_atmos_model_down)
           endif
-          if (do_chksum) call atmos_ice_land_chksum('update_atmos_down+', (nc-1)*num_atmos_calls+na, &
-                                                    coupler_chksum_obj)
+          if (do_chksum) call coupler_chksum_obj%atmos_ice_land_chksum('update_atmos_down+', current_timestep)
           if (do_debug)  call fms_memutils_print_memuse_stats( 'update down')
 
           call fms_mpp_clock_begin(coupler_clocks%flux_down_from_atmos)
@@ -581,8 +581,7 @@ program coupler_main
                                      Atmos_land_boundary, &
                                      Atmos_ice_boundary )
           call fms_mpp_clock_end(coupler_clocks%flux_down_from_atmos)
-          if (do_chksum) call atmos_ice_land_chksum('flux_down_from_atmos+', (nc-1)*num_atmos_calls+na,&
-                                                    coupler_chksum_obj)
+          if (do_chksum) call coupler_chksum_obj%atmos_ice_land_chksum('flux_down_from_atmos+', current_timestep)
 
           !      --------------------------------------------------------------
           !      ---- land model ----
@@ -593,8 +592,7 @@ program coupler_main
           endif
           if (land_npes .NE. atmos_npes) call fms_mpp_set_current_pelist(Atm%pelist)
           call fms_mpp_clock_end(coupler_clocks%update_land_model_fast)
-          if (do_chksum) call atmos_ice_land_chksum('update_land_fast+', (nc-1)*num_atmos_calls+na, &
-                                                    coupler_chksum_obj)
+          if (do_chksum) call coupler_chksum_obj%atmos_ice_land_chksum('update_land_fast+', current_timestep)
           if (do_debug)  call fms_memutils_print_memuse_stats( 'update land')
 
           !      ---- ice model ----
@@ -605,8 +603,7 @@ program coupler_main
           endif
           if (ice_npes .NE. atmos_npes) call fms_mpp_set_current_pelist(Atm%pelist)
           call fms_mpp_clock_end(coupler_clocks%update_ice_model_fast)
-          if (do_chksum) call atmos_ice_land_chksum('update_ice_fast+', (nc-1)*num_atmos_calls+na,&
-                                                    coupler_chksum_obj)
+          if (do_chksum) call coupler_chksum_obj%atmos_ice_land_chksum('update_ice_fast+', current_timestep)
           if (do_debug)  call fms_memutils_print_memuse_stats( 'update ice')
 
           !      --------------------------------------------------------------
@@ -615,14 +612,13 @@ program coupler_main
           call flux_up_to_atmos( Time_atmos, Land, Ice, Land_ice_atmos_boundary, &
                                  Atmos_land_boundary, Atmos_ice_boundary )
           call fms_mpp_clock_end(coupler_clocks%flux_up_to_atmos)
-          if (do_chksum) call atmos_ice_land_chksum('flux_up2atmos+', (nc-1)*num_atmos_calls+na,coupler_chksum_obj)
+          if (do_chksum) call coupler_chksum_obj%atmos_ice_land_chksum('flux_up2atmos+', current_timestep)
 
           call fms_mpp_clock_begin(coupler_clocks%update_atmos_model_up)
           if (do_atmos) &
             call update_atmos_model_up( Land_ice_atmos_boundary, Atm)
           call fms_mpp_clock_end(coupler_clocks%update_atmos_model_up)
-          if (do_chksum) call atmos_ice_land_chksum('update_atmos_up+', (nc-1)*num_atmos_calls+na, &
-                                                    coupler_chksum_obj)
+          if (do_chksum) call coupler_chksum_obj%atmos_ice_land_chksum('update_atmos_up+', current_timestep)
           if (do_debug)  call fms_memutils_print_memuse_stats( 'update up')
 
           call flux_atmos_to_ocean(Time_atmos, Atm, Atmos_ice_boundary, Ice)
@@ -667,8 +663,7 @@ program coupler_main
 
         call fms_mpp_clock_begin(coupler_clocks%update_atmos_model_state)
         call update_atmos_model_state( Atm )
-        if (do_chksum) call atmos_ice_land_chksum('update_atmos_model_state+', (nc-1)*num_atmos_calls+na,&
-                                                  coupler_chksum_obj)
+        if (do_chksum) call coupler_chksum_obj%atmos_ice_land_chksum('update_atmos_model_state+', current_timestep)
         if (do_debug)  call fms_memutils_print_memuse_stats( 'update state')
         call fms_mpp_clock_end(coupler_clocks%update_atmos_model_state)
 
@@ -685,15 +680,15 @@ program coupler_main
       if (land_npes .NE. atmos_npes) call fms_mpp_set_current_pelist(Atm%pelist)
       !-----------------------------------------------------------------------
       call fms_mpp_clock_end(coupler_clocks%update_land_model_slow)
-      if (do_chksum) call atmos_ice_land_chksum('update_land_slow+', nc, coupler_chksum_obj)
-
+      if (do_chksum) call coupler_chksum_obj%atmos_ice_land_chksum('update_land_slow+', nc)
+      
       !
       !     need flux call to put runoff and p_surf on ice grid
       !
       call fms_mpp_clock_begin(coupler_clocks%flux_land_to_ice)
       call flux_land_to_ice( Time, Land, Ice, Land_ice_boundary )
       call fms_mpp_clock_end(coupler_clocks%flux_land_to_ice)
-      if (do_chksum) call atmos_ice_land_chksum('fluxlnd2ice+', nc, coupler_chksum_obj)
+      if (do_chksum) call coupler_chksum_obj%atmos_ice_land_chksum('fluxlnd2ice+', nc)
 
       Atmos_ice_boundary%p = 0.0 ! call flux_atmos_to_ice_slow ?
       Time = Time_atmos
@@ -734,7 +729,7 @@ program coupler_main
         call fms_mpp_clock_end(coupler_clocks%update_ice_model_slow_slow)
       endif
 
-      if (do_chksum) call slow_ice_chksum('update_ice_slow+', nc, coupler_chksum_obj)
+      if (do_chksum) call coupler_chksum_obj%slow_ice_chksum('update_ice_slow+', nc)
      endif  ! End of Ice%pe block
 
      if(Atm%pe) then
@@ -771,7 +766,7 @@ program coupler_main
                                  Time_ocean, Time_step_cpld )
       endif
 
-      if (do_chksum) call ocean_chksum('update_ocean_model+', nc, coupler_chksum_obj)
+      if (do_chksum) call coupler_chksum_obj%ocean_chksum('update_ocean_model+', nc)
       ! Get stocks from "Ice_ocean_boundary" and add them to Ocean stocks.
       ! This call is just for record keeping of stocks transfer and
       ! does not modify either Ocean or Ice_ocean_boundary
@@ -828,7 +823,7 @@ program coupler_main
   call fms_mpp_clock_end(coupler_clocks%main)
   call fms_mpp_clock_begin(coupler_clocks%termination)
 
-  if (do_chksum) call coupler_chksum('coupler_end-', nc, coupler_chksum_obj)
+  if (do_chksum) call coupler_chksum_obj%coupler_chksum('coupler_end-', nc)
   call coupler_end(Atm, Land, Ice, Ocean, Ocean_state, Land_ice_atmos_boundary, Atmos_ice_boundary,&
       Atmos_land_boundary, Ice_ocean_boundary, Ocean_ice_boundary, Ocn_bc_restart, Ice_bc_restart, &
       Time, Time_start, Time_end, Time_restart_current, coupler_chksum_obj)

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -814,8 +814,6 @@ program coupler_main
     imb_sec(:)=0.
     call flush(outunit)
 
-    stop
-    
   enddo
 102 FORMAT(A17,i5,A4,i5,A24,f10.4,A2,f10.4,A3,f10.4,A2,f10.4,A1)
 

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -570,12 +570,12 @@ program coupler_main
           !--------------------------------------------------------------
 
           !> land model 
-          if (do_land .AND. land%pe) call update_land_model_fast(Land, Atmos_land_boundary, current_timestep,&
-                                                                 coupler_chksum_obj, coupler_clocks)
+          if (do_land .AND. land%pe) call coupler_update_land_model_fast(Land, Atmos_land_boundary, Atm%pelist, &
+                                     current_timestep, coupler_chksum_obj, coupler_clocks)
 
           !> ice model
-          if (do_ice .AND. Ice%fast_ice_pe) call update_ice_model_fast(Ice, Atmos_ice_boundary, current_timestep,&
-                                                                       coupler_chksum_obj, coupler_clocks)
+          if (do_ice .AND. Ice%fast_ice_pe) call coupler_update_ice_model_fast(Ice, Atmos_ice_boundary, Atm%pelist, &
+                                            current_timestep, coupler_chksum_obj, coupler_clocks)
 
           !--------------------------------------------------------------
 

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -513,7 +513,7 @@ program coupler_main
       !> atmos/fast-land/fast-ice integration loop 
 
       call fms_mpp_clock_begin(coupler_clocks%atmos_loop)
-      do na = 1, num_atmos_calls
+      fast_integration_loop : do na = 1, num_atmos_calls
 
         Time_atmos = Time_atmos + Time_step_atmos
         current_timestep = (nc-1)*num_atmos_calls+na
@@ -616,14 +616,9 @@ program coupler_main
 !$      if (do_concurrent_radiation) imb_sec(2) = imb_sec(2) + omp_get_wtime()
 !$      call omp_set_num_threads(atmos_nthreads+(conc_nthreads-1)*radiation_nthreads)
 
-        call fms_mpp_clock_begin(coupler_clocks%update_atmos_model_state)
-        call update_atmos_model_state( Atm )
-        if (do_chksum) call atmos_ice_land_chksum('update_atmos_model_state+', (nc-1)*num_atmos_calls+na, Atm, Land, &
-                  Ice,Land_ice_atmos_boundary, Atmos_ice_boundary, Atmos_land_boundary)
-        if (do_debug)  call fms_memutils_print_memuse_stats( 'update state')
-        call fms_mpp_clock_end(coupler_clocks%update_atmos_model_state)
-
-      enddo ! end of na (fast loop)
+        call coupler_update_atmos_model_state(Atm, current_timestep, coupler_chksum_obj, coupler_clocks )
+        
+      enddo fast_integration_loop ! end of na (fast loop)
 
       call fms_mpp_clock_end(coupler_clocks%atmos_loop)
 

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -339,21 +339,22 @@ program coupler_main
   use iso_fortran_env
   implicit none
 
-  !> model defined types
-  type (atmos_data_type) :: Atm
-  type  (land_data_type) :: Land
-  type   (ice_data_type) :: Ice
+  !> model defined types.
+  !! Targets to pointers in coupler_chksum_obj
+  type (atmos_data_type), target :: Atm
+  type  (land_data_type), target :: Land
+  type   (ice_data_type), target :: Ice
   ! allow members of ocean type to be aliased (ap)
-  type (ocean_public_type), target  :: Ocean
+  type (ocean_public_type), target  :: Ocean 
   type (ocean_state_type),  pointer :: Ocean_state => NULL()
 
-  type(atmos_land_boundary_type) :: Atmos_land_boundary
-  type(atmos_ice_boundary_type)  :: Atmos_ice_boundary
-  type(land_ice_atmos_boundary_type)  :: Land_ice_atmos_boundary
-  type(land_ice_boundary_type)  :: Land_ice_boundary
-  type(ice_ocean_boundary_type) :: Ice_ocean_boundary
-  type(ocean_ice_boundary_type) :: Ocean_ice_boundary
-  type(ice_ocean_driver_type), pointer :: ice_ocean_driver_CS => NULL()
+  type(atmos_land_boundary_type), target :: Atmos_land_boundary
+  type(atmos_ice_boundary_type), target  :: Atmos_ice_boundary
+  type(land_ice_atmos_boundary_type), target  :: Land_ice_atmos_boundary
+  type(land_ice_boundary_type), target  :: Land_ice_boundary
+  type(ice_ocean_boundary_type), target :: Ice_ocean_boundary
+  type(ocean_ice_boundary_type), target :: Ocean_ice_boundary
+  type(ice_ocean_driver_type), pointer  :: ice_ocean_driver_CS => NULL()
 
   type(FmsTime_type) :: Time
   type(FmsTime_type) :: Time_step_atmos, Time_step_cpld
@@ -371,6 +372,7 @@ program coupler_main
   character(len=32) :: timestamp
 
   type(coupler_clock_type) :: coupler_clocks
+  class(coupler_chksum_type) :: coupler_chksum_obj
 
   integer :: outunit
   character(len=80) :: text
@@ -426,7 +428,7 @@ program coupler_main
   call coupler_init(Atm, Ocean, Land, Ice, Ocean_state, Atmos_land_boundary, Atmos_ice_boundary, &
     Ocean_ice_boundary, Ice_ocean_boundary, Land_ice_atmos_boundary, Land_ice_boundary,          &
     Ice_ocean_driver_CS, Ice_bc_restart, Ocn_bc_restart, ensemble_pelist, slow_ice_ocean_pelist, &
-    conc_nthreads, coupler_clocks, Time_step_cpld, Time_step_atmos, Time_atmos, Time_ocean,      &
+    conc_nthreads, coupler_clocks, coupler_chksum_obj, Time_step_cpld, Time_step_atmos, Time_atmos, Time_ocean, &
     num_cpld_calls, num_atmos_calls, Time, Time_start, Time_end, Time_restart, Time_restart_current)
 
   if (do_chksum) call coupler_chksum('coupler_init+', 0, Atm, Land, Ice)

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -682,7 +682,7 @@ program coupler_main
       !-----------------------------------------------------------------------
       call fms_mpp_clock_end(coupler_clocks%update_land_model_slow)
       if (do_chksum) call coupler_chksum_obj%get_atmos_ice_land_chksums('update_land_slow+', nc)
-      
+
       !
       !     need flux call to put runoff and p_surf on ice grid
       !

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -345,7 +345,7 @@ program coupler_main
   type  (land_data_type), target :: Land
   type   (ice_data_type), target :: Ice
   ! allow members of ocean type to be aliased (ap)
-  type (ocean_public_type), target  :: Ocean 
+  type (ocean_public_type), target  :: Ocean
   type (ocean_state_type),  pointer :: Ocean_state => NULL()
 
   type(atmos_land_boundary_type), target :: Atmos_land_boundary
@@ -439,7 +439,7 @@ program coupler_main
   call fms_mpp_clock_begin(coupler_clocks%main)         !begin main loop
 
 !-----------------------------------------------------------------------
-!> ocean/slow-ice integration loop 
+!> ocean/slow-ice integration loop
 
   if (check_stocks >= 0) call coupler_flux_init_finish_stocks(Time, Atm, Land, Ice, Ocean_state, &
                                                               coupler_clocks, init_stocks=.True.)
@@ -510,7 +510,7 @@ program coupler_main
 
       !-----------------------------------------------------------------------
 
-      !> atmos/fast-land/fast-ice integration loop 
+      !> atmos/fast-land/fast-ice integration loop
 
       call fms_mpp_clock_begin(coupler_clocks%atmos_loop)
       fast_integration_loop : do na = 1, num_atmos_calls
@@ -526,7 +526,7 @@ program coupler_main
         if (do_flux) call coupler_sfc_boundary_layer(Atm, Land, Ice, Land_ice_atmos_boundary, &
                                                      Time_atmos, current_timestep, coupler_chksum_obj, coupler_clocks)
 
-        
+
 !$OMP   PARALLEL  &
 !$OMP&    NUM_THREADS(conc_nthreads)  &
 !$OMP&    DEFAULT(NONE)  &
@@ -569,7 +569,7 @@ program coupler_main
 
           !--------------------------------------------------------------
 
-          !> land model 
+          !> land model
           if (do_land .AND. land%pe) call coupler_update_land_model_fast(Land, Atmos_land_boundary, Atm%pelist, &
                                      current_timestep, coupler_chksum_obj, coupler_clocks)
 
@@ -579,10 +579,10 @@ program coupler_main
 
           !--------------------------------------------------------------
 
-          !> atmosphere up 
+          !> atmosphere up
           call coupler_flux_up_to_atmos(Land, Ice, Land_ice_atmos_boundary, Atmos_land_boundary, Atmos_ice_boundary,&
                                         Time_atmos, current_timestep, coupler_chksum_obj, coupler_clocks)
-          
+
           if (do_atmos) call coupler_update_atmos_model_up(Atm, Land_ice_atmos_boundary, current_timestep, &
                                                            coupler_chksum_obj, coupler_clocks)
 
@@ -617,7 +617,7 @@ program coupler_main
 !$      call omp_set_num_threads(atmos_nthreads+(conc_nthreads-1)*radiation_nthreads)
 
         call coupler_update_atmos_model_state(Atm, current_timestep, coupler_chksum_obj, coupler_clocks )
-        
+
       enddo fast_integration_loop ! end of na (fast loop)
 
       call fms_mpp_clock_end(coupler_clocks%atmos_loop)

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -506,10 +506,6 @@ program coupler_main
       call send_ice_mask_sic(Time)
 
       !-----------------------------------------------------------------------
-<<<<<<< HEAD
-
-=======
->>>>>>> origin/atmos_model-flux_down
       !> atmos/fast-land/fast-ice integration loop
 
       call fms_mpp_clock_begin(coupler_clocks%atmos_loop)
@@ -566,7 +562,6 @@ program coupler_main
           call coupler_flux_down_from_atmos(Atm, Land, Ice, Land_ice_atmos_boundary, Atmos_land_boundary, &
                                             Atmos_ice_boundary, Time_atmos, current_timestep, coupler_clocks)
 
-<<<<<<< HEAD
           !--------------------------------------------------------------
 
           !> land model
@@ -578,46 +573,6 @@ program coupler_main
                                             current_timestep, coupler_chksum_obj, coupler_clocks)
 
           !--------------------------------------------------------------
-=======
-          !      --------------------------------------------------------------
-          !      ---- land model ----
-          call fms_mpp_clock_begin(coupler_clocks%update_land_model_fast)
-          if (do_land .AND. land%pe) then
-            if (land_npes .NE. atmos_npes) call fms_mpp_set_current_pelist(Land%pelist)
-            call update_land_model_fast( Atmos_land_boundary, Land )
-          endif
-          if (land_npes .NE. atmos_npes) call fms_mpp_set_current_pelist(Atm%pelist)
-          call fms_mpp_clock_end(coupler_clocks%update_land_model_fast)
-          if (do_chksum) call coupler_chksum_obj%get_atmos_ice_land_chksums('update_land_fast+', current_timestep)
-          if (do_debug)  call fms_memutils_print_memuse_stats( 'update land')
-
-          !      ---- ice model ----
-          call fms_mpp_clock_begin(coupler_clocks%update_ice_model_fast)
-          if (do_ice .AND. Ice%fast_ice_pe) then
-            if (ice_npes .NE. atmos_npes)call fms_mpp_set_current_pelist(Ice%fast_pelist)
-            call update_ice_model_fast( Atmos_ice_boundary, Ice )
-          endif
-          if (ice_npes .NE. atmos_npes) call fms_mpp_set_current_pelist(Atm%pelist)
-          call fms_mpp_clock_end(coupler_clocks%update_ice_model_fast)
-          if (do_chksum) call coupler_chksum_obj%get_atmos_ice_land_chksums('update_ice_fast+', current_timestep)
-          if (do_debug)  call fms_memutils_print_memuse_stats( 'update ice')
-
-          !      --------------------------------------------------------------
-          !      ---- atmosphere up ----
-          call fms_mpp_clock_begin(coupler_clocks%flux_up_to_atmos)
-          call flux_up_to_atmos( Time_atmos, Land, Ice, Land_ice_atmos_boundary, &
-                                 Atmos_land_boundary, Atmos_ice_boundary )
-          call fms_mpp_clock_end(coupler_clocks%flux_up_to_atmos)
-          if (do_chksum) call coupler_chksum_obj%get_atmos_ice_land_chksums('flux_up2atmos+', current_timestep)
-
-          call fms_mpp_clock_begin(coupler_clocks%update_atmos_model_up)
-          if (do_atmos) &
-            call update_atmos_model_up( Land_ice_atmos_boundary, Atm)
-          call fms_mpp_clock_end(coupler_clocks%update_atmos_model_up)
-          if (do_chksum) call coupler_chksum_obj%get_atmos_ice_land_chksums('update_atmos_up+', current_timestep)
-          if (do_debug)  call fms_memutils_print_memuse_stats( 'update up')
->>>>>>> origin/atmos_model-flux_down
-
           !> atmosphere up
           call coupler_flux_up_to_atmos(Land, Ice, Land_ice_atmos_boundary, Atmos_land_boundary, Atmos_ice_boundary,&
                                         Time_atmos, current_timestep, coupler_chksum_obj, coupler_clocks)
@@ -655,15 +610,7 @@ program coupler_main
 !$      if (do_concurrent_radiation) imb_sec(2) = imb_sec(2) + omp_get_wtime()
 !$      call omp_set_num_threads(atmos_nthreads+(conc_nthreads-1)*radiation_nthreads)
 
-<<<<<<< HEAD
         call coupler_update_atmos_model_state(Atm, current_timestep, coupler_chksum_obj, coupler_clocks )
-=======
-        call fms_mpp_clock_begin(coupler_clocks%update_atmos_model_state)
-        call update_atmos_model_state( Atm )
-        if (do_chksum) call coupler_chksum_obj%get_atmos_ice_land_chksums('update_atmos_model_state+', current_timestep)
-        if (do_debug)  call fms_memutils_print_memuse_stats( 'update state')
-        call fms_mpp_clock_end(coupler_clocks%update_atmos_model_state)
->>>>>>> origin/atmos_model-flux_down
 
       enddo fast_integration_loop ! end of na (fast loop)
 

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -345,7 +345,7 @@ program coupler_main
   type  (land_data_type), target :: Land
   type   (ice_data_type), target :: Ice
   ! allow members of ocean type to be aliased (ap)
-  type (ocean_public_type), target  :: Ocean 
+  type (ocean_public_type), target  :: Ocean
   type (ocean_state_type),  pointer :: Ocean_state => NULL()
 
   type(atmos_land_boundary_type), target :: Atmos_land_boundary
@@ -439,7 +439,7 @@ program coupler_main
   call fms_mpp_clock_begin(coupler_clocks%main)         !begin main loop
 
 !-----------------------------------------------------------------------
-!> ocean/slow-ice integration loop 
+!> ocean/slow-ice integration loop
 
   if (check_stocks >= 0) call coupler_flux_init_finish_stocks(Time, Atm, Land, Ice, Ocean_state, &
                                                               coupler_clocks, init_stocks=.True.)
@@ -509,7 +509,7 @@ program coupler_main
       call send_ice_mask_sic(Time)
 
       !-----------------------------------------------------------------------
-      !> atmos/fast-land/fast-ice integration loop 
+      !> atmos/fast-land/fast-ice integration loop
 
       call fms_mpp_clock_begin(coupler_clocks%atmos_loop)
       do na = 1, num_atmos_calls
@@ -525,7 +525,7 @@ program coupler_main
         if (do_flux) call coupler_sfc_boundary_layer(Atm, Land, Ice, Land_ice_atmos_boundary, &
                                                      Time_atmos, current_timestep, coupler_chksum_obj, coupler_clocks)
 
-        
+
 !$OMP   PARALLEL  &
 !$OMP&    NUM_THREADS(conc_nthreads)  &
 !$OMP&    DEFAULT(NONE)  &

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -373,7 +373,7 @@ program coupler_main
   character(len=32) :: timestamp
 
   type(coupler_clock_type)      :: coupler_clocks
-  type(coupler_components_type) :: coupler_components_obj
+  type(coupler_components_type), target :: coupler_components_obj
   type(coupler_chksum_type)     :: coupler_chksum_obj
 
   integer :: outunit

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -372,7 +372,7 @@ program coupler_main
   character(len=32) :: timestamp
 
   type(coupler_clock_type) :: coupler_clocks
-  class(coupler_chksum_type) :: coupler_chksum_obj
+  class(coupler_chksum_type) :: coupler_chksum_ojb
 
   integer :: outunit
   character(len=80) :: text
@@ -550,7 +550,7 @@ program coupler_main
           !      ---- atmosphere dynamics ----
           if (do_atmos) then
             call fms_mpp_clock_begin(coupler_clocks%update_atmos_model_dynamics)
-            call update_atmos_model_dynamics( Atm )
+            call update_atmos_model_dynamics( Atm, chksum%set_id('id', timestep ))
             call fms_mpp_clock_end(coupler_clocks%update_atmos_model_dynamics)
           endif
           if (do_chksum) call atmos_ice_land_chksum('update_atmos_model_dynamics', (nc-1)*num_atmos_calls+na, &

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -560,7 +560,7 @@ program coupler_main
 
           !> checksums are computed if do_chksum=.True.
           call coupler_flux_down_from_atmos(Atm, Land, Ice, Land_ice_atmos_boundary, Atmos_land_boundary, &
-                                            Atmos_ice_boundary, Time_atmos, current_timestep, coupler_clocks)
+              Atmos_ice_boundary, Time_atmos, current_timestep, coupler_clocks, coupler_chksum_obj)
 
           !      --------------------------------------------------------------
           !      ---- land model ----

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -345,7 +345,7 @@ program coupler_main
   type  (land_data_type), target :: Land
   type   (ice_data_type), target :: Ice
   ! allow members of ocean type to be aliased (ap)
-  type (ocean_public_type), target  :: Ocean 
+  type (ocean_public_type), target  :: Ocean
   type (ocean_state_type),  pointer :: Ocean_state => NULL()
 
   type(atmos_land_boundary_type), target :: Atmos_land_boundary
@@ -526,7 +526,7 @@ program coupler_main
         if (do_flux) call coupler_sfc_boundary_layer(Atm, Land, Ice, Land_ice_atmos_boundary, &
                                                      Time_atmos, current_timestep, coupler_chksum_obj, coupler_clocks)
 
-        
+
 !$OMP   PARALLEL  &
 !$OMP&    NUM_THREADS(conc_nthreads)  &
 !$OMP&    DEFAULT(NONE)  &

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -512,25 +512,15 @@ program coupler_main
       call fms_mpp_clock_begin(coupler_clocks%atmos_loop)
       do na = 1, num_atmos_calls
         if (do_chksum) call atmos_ice_land_chksum('top_of_atmos_loop-', (nc-1)*num_atmos_calls+na, Atm, Land, Ice, &
-                 Land_ice_atmos_boundary, Atmos_ice_boundary, Atmos_land_boundary)
+                                                  Land_ice_atmos_boundary, Atmos_ice_boundary, Atmos_land_boundary)
 
         Time_atmos = Time_atmos + Time_step_atmos
 
-        if (do_atmos) then
-          call fms_mpp_clock_begin(coupler_clocks%atmos_tracer_driver_gather_data)
-          call atmos_tracer_driver_gather_data(Atm%fields, Atm%tr_bot)
-          call fms_mpp_clock_end(coupler_clocks%atmos_tracer_driver_gather_data)
-        endif
+        if (do_atmos) call coupler_atmos_tracer_driver_gather_data(Atm, coupler_clocks)
 
-        if (do_flux) then
-          call fms_mpp_clock_begin(coupler_clocks%sfc_boundary_layer)
-          call sfc_boundary_layer( REAL(dt_atmos), Time_atmos, &
-               Atm, Land, Ice, Land_ice_atmos_boundary )
-          if (do_chksum)  call atmos_ice_land_chksum('sfc+', (nc-1)*num_atmos_calls+na, Atm, Land, Ice, &
-                 Land_ice_atmos_boundary, Atmos_ice_boundary, Atmos_land_boundary)
-          call fms_mpp_clock_end(coupler_clocks%sfc_boundary_layer)
-        endif
-
+        if (do_flux) call coupler_sfc_boundary_layer(Atm, Land, Ice, Land_ice_atmos_boundary, &
+            Atmos_ice_boundary,Atmos_land_boundary, Time_atmos, (nc-1)*num_atmos_calls+na, coupler_clocks)
+        
 !$OMP   PARALLEL  &
 !$OMP&    NUM_THREADS(conc_nthreads)  &
 !$OMP&    DEFAULT(NONE)  &

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -434,7 +434,9 @@ program coupler_main
     Time_step_cpld, Time_step_atmos, Time_atmos, Time_ocean, num_cpld_calls,   &
     num_atmos_calls, Time, Time_start, Time_end, Time_restart, Time_restart_current)
 
-  if (do_chksum) call coupler_chksum_obj%get_coupler_chksums('coupler_init+', 0)
+  do_chksum = .True.
+  
+  !if (do_chksum) call coupler_chksum_obj%get_coupler_chksums('coupler_init+', 0)
 
   call fms_mpp_set_current_pelist()
   call fms_mpp_clock_end(coupler_clocks%initialization) !end initialization
@@ -450,7 +452,7 @@ program coupler_main
   do nc = 1, num_cpld_calls
 
     if (do_chksum) then
-      call coupler_chksum_obj%get_coupler_chksums('top_of_coupled_loop+', nc)
+      !call coupler_chksum_obj%get_coupler_chksums('top_of_coupled_loop+', nc)
       call coupler_chksum_obj%get_atmos_ice_land_ocean_chksums('MAIN_LOOP-', nc)
     end if
 
@@ -472,7 +474,7 @@ program coupler_main
     end if
 
     if (do_chksum) then
-      call coupler_chksum_obj%get_coupler_chksums('flux_ocn2ice+', nc)
+      !call coupler_chksum_obj%get_coupler_chksums('flux_ocn2ice+', nc)
       call coupler_chksum_obj%get_atmos_ice_land_ocean_chksums('flux_ocn2ice+', nc)
     end if
 
@@ -802,7 +804,7 @@ program coupler_main
     endif
 
     !--------------
-    if (do_chksum) call coupler_chksum_obj%get_coupler_chksums('MAIN_LOOP+', nc)
+    !if (do_chksum) call coupler_chksum_obj%get_coupler_chksums('MAIN_LOOP+', nc)
     write( text,'(a,i6)' )'Main loop at coupling timestep=', nc
     call fms_memutils_print_memuse_stats(text)
     outunit= fms_mpp_stdout()
@@ -814,6 +816,8 @@ program coupler_main
     imb_sec(:)=0.
     call flush(outunit)
 
+    stop
+    
   enddo
 102 FORMAT(A17,i5,A4,i5,A24,f10.4,A2,f10.4,A3,f10.4,A2,f10.4,A1)
 

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -1113,6 +1113,7 @@ contains
                                                     Atmos_land_boundary,Atmos_ice_boundary, Land_ice_boundary, &
                                                     Ice_ocean_boundary, Ocean_ice_boundary)
 
+    do_endpoint_chksum = .False.
     if ( do_endpoint_chksum ) then
       call coupler_atmos_ice_land_ocean_chksum('coupler_init+', 0, Atm, Land, Ice, &
           Land_ice_atmos_boundary, Atmos_ice_boundary, Atmos_land_boundary, Ocean, Ice_ocean_boundary)
@@ -1949,7 +1950,7 @@ contains
     call fms_mpp_clock_begin(coupler_clocks%sfc_boundary_layer)
 
     call sfc_boundary_layer( real(dt_atmos), Time_atmos, Atm, Land, Ice, Land_ice_atmos_boundary )
-    if (do_chksum)  call atmos_ice_land_chksum('sfc+', current_time_step, Atm, Land, Ice, &
+    call atmos_ice_land_chksum('sfc+', current_time_step, Atm, Land, Ice, &
         Land_ice_atmos_boundary, coupler_chksum_obj%Atmos_ice_boundary,                   &
         coupler_chksum_obj%Atmos_land_boundary)
     

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -287,7 +287,7 @@ module full_coupler_mod
     type(ice_ocean_boundary_type),  pointer :: Ice_ocean_boundary  !< pointer to Ice_ocean_boundary
     type(ocean_ice_boundary_type),  pointer :: Ocean_ice_boundary  !< pointer to Ocean_ice_boundary
   contains
-    procedure, public :: coupler_components_obj_init
+    procedure, public :: initialize_coupler_components_obj
     procedure, public :: get_component  !< subroutine to retrieve the requested component of an object of this type
     procedure, public :: set_component  !< subroutine to set requested component of an object of this type
   end type coupler_components_type
@@ -299,7 +299,7 @@ module full_coupler_mod
     private
     type(coupler_components_type), pointer :: components
   contains
-    procedure, public :: coupler_chksum_obj_init !< associates the pointers above to model components
+    procedure, public :: initialize_coupler_chksum_obj !< associates the pointers above to model components
     procedure, public :: get_components_obj !< subroutine to retrieve the requested component of an object of this type
     procedure, public :: set_components_obj !< subroutine to set components object
     procedure, public :: get_atmos_ice_land_ocean_chksums !< subroutine to compute chksums for atmos - ocean
@@ -1127,11 +1127,11 @@ contains
 !-----------------------------------------------------------------------
 
     !> Initialize coupler_components_obj memebers to point to model components
-    call coupler_components_obj%coupler_components_obj_init(Atm, Land, Ice, Ocean, Land_ice_atmos_boundary, &
+    call coupler_components_obj%initialize_coupler_components_obj(Atm, Land, Ice, Ocean, Land_ice_atmos_boundary,&
         Atmos_land_boundary, Atmos_ice_boundary, Land_ice_boundary, Ice_ocean_boundary, Ocean_ice_boundary)
 
     !> Initialize coupler_chksum_obj
-    call coupler_chksum_obj%coupler_chksum_obj_init(coupler_components_obj)
+    call coupler_chksum_obj%initialize_coupler_chksum_obj(coupler_components_obj)
 
     if ( do_endpoint_chksum ) then
       call coupler_chksum_obj%get_atmos_ice_land_ocean_chksums('coupler_init+', 0)
@@ -1154,8 +1154,8 @@ contains
 !#######################################################################
 
   !> This subroutine associates the pointer in an object of coupler_components_type to the model components
-  subroutine coupler_components_obj_init(this, Atm, Land, Ice, Ocean, Land_ice_atmos_boundary, Atmos_land_boundary, &
-                                         Atmos_ice_boundary, Land_ice_boundary, Ice_ocean_boundary, Ocean_ice_boundary)
+  subroutine initialize_coupler_components_obj(this, Atm, Land, Ice, Ocean, Land_ice_atmos_boundary, &
+      Atmos_land_boundary, Atmos_ice_boundary, Land_ice_boundary, Ice_ocean_boundary, Ocean_ice_boundary)
 
     implicit none
     class(coupler_components_type), intent(inout) :: this !< self
@@ -1181,7 +1181,7 @@ contains
     this%Ice_ocean_boundary => Ice_ocean_boundary
     this%Ocean_ice_boundary => Ocean_ice_boundary
 
-  end subroutine coupler_components_obj_init
+  end subroutine initialize_coupler_components_obj
 
   !> Function get_component returns the requested component in the coupler_components_type object
   !! Users are required to provide the component to be retrieved as an input argument.  For example,
@@ -1246,7 +1246,7 @@ contains
   end subroutine set_component
 
   !> This subroutine associates the pointer in an object of coupler_chksum_type to the component models
-  subroutine coupler_chksum_obj_init(this, components_obj)
+  subroutine initialize_coupler_chksum_obj(this, components_obj)
 
     implicit none
     class(coupler_chksum_type), intent(inout) :: this
@@ -1254,7 +1254,7 @@ contains
 
     this%components = components_obj
 
-  end subroutine coupler_chksum_obj_init
+  end subroutine initialize_coupler_chksum_obj
 
   !> This subroutine retrieves coupler_chksum_obj%components_obj
   subroutine get_components_obj(this, components_obj)

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -1897,7 +1897,7 @@ contains
     type(coupler_clock_type), intent(in) :: coupler_clocks !< coupler_clocks
                                                                                 
     call fms_mpp_clock_begin(coupler_clocks%sfc_boundary_layer)
-    call sfc_boundary_layer( dt_atmos, Time_atmos, Atm, Land, Ice, Land_ice_atmos_boundary )
+    call sfc_boundary_layer( real(dt_atmos), Time_atmos, Atm, Land, Ice, Land_ice_atmos_boundary )
     if (do_chksum)  call atmos_ice_land_chksum('sfc+', current_time_step, Atm, Land, Ice, &
                                                Land_ice_atmos_boundary, Atmos_ice_boundary, Atmos_land_boundary)
     call fms_mpp_clock_end(coupler_clocks%sfc_boundary_layer)

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -1983,7 +1983,7 @@ contains
   !> \brief This subroutine calls coupler_sfc_boundary_layer.  Chksums are computed
   !! if do_chksum = .True.  Clocks are set for runtime statistics.
   subroutine coupler_sfc_boundary_layer(Atm, Land, Ice, Land_ice_atmos_boundary, &
-                                        Time_atmos, current_time_step, coupler_chksum_obj, coupler_clocks)
+                                        Time_atmos, current_timestep, coupler_chksum_obj, coupler_clocks)
 
     implicit none
     type(atmos_data_type), intent(inout) :: Atm  !< Atm
@@ -1991,7 +1991,7 @@ contains
     type(ice_data_type), intent(inout)   :: Ice  !< Ice
     type(land_ice_atmos_boundary_type), intent(inout) :: Land_ice_atmos_boundary !< Land_ice_atmos_boundary
     type(FmsTime_type), intent(in) :: Time_atmos           !< Atmos time
-    integer, intent(in)            :: current_time_step    !< (nc-1)*num_atmos_cal + na
+    integer, intent(in)            :: current_timestep     !< (nc-1)*num_atmos_cal + na
     type(coupler_chksum_type), intent(in)   :: coupler_chksum_obj
     type(coupler_clock_type), intent(inout) :: coupler_clocks !< coupler_clocks
 

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -133,7 +133,7 @@ module full_coupler_mod
   public :: coupler_update_land_model_fast, coupler_update_ice_model_fast
   public :: coupler_flux_up_to_atmos, coupler_update_atmos_model_up
   public :: coupler_flux_atmos_to_ocean, coupler_update_atmos_model_state
-  
+
   public :: coupler_clock_type, coupler_chksum_type
 
 #include <file_version.fh>
@@ -276,9 +276,9 @@ module full_coupler_mod
     integer :: ocean_model_init
     integer :: flux_exchange_init
   end type coupler_clock_type
-  
+
   type coupler_chksum_type
-    type(atmos_data_type), pointer :: Atm    
+    type(atmos_data_type), pointer :: Atm
     type(land_data_type),  pointer :: Land
     type(ice_data_type),   pointer :: Ice
     type(ocean_public_type), pointer :: Ocean
@@ -291,7 +291,7 @@ module full_coupler_mod
   contains
     procedure :: coupler_chksum_obj_init
   end type coupler_chksum_type
-  
+
   character(len=80) :: text
   character(len=48), parameter :: mod_name = 'coupler_main_mod'
 
@@ -1148,7 +1148,7 @@ contains
     type(land_ice_boundary_type),   target, intent(in) :: Land_ice_boundary
     type(ice_ocean_boundary_type),  target, intent(in) :: Ice_ocean_boundary
     type(ocean_ice_boundary_type),  target, intent(in) :: Ocean_ice_boundary
-    
+
     self%Atm => Atm
     self%Land => Land
     self%Ice => Ice
@@ -1158,11 +1158,11 @@ contains
     self%Atmos_ice_boundary => Atmos_ice_boundary
     self%Land_ice_boundary => Land_ice_boundary
     self%Ice_ocean_boundary => Ice_ocean_boundary
-    self%Ocean_ice_boundary => Ocean_ice_boundary   
+    self%Ocean_ice_boundary => Ocean_ice_boundary
 
   end subroutine coupler_chksum_obj_init
 
-  
+
   subroutine coupler_end(Atm, Land, Ice, Ocean, Ocean_state, Land_ice_atmos_boundary, Atmos_ice_boundary,&
                          Atmos_land_boundary, Ice_ocean_boundary, Ocean_ice_boundary, Ocn_bc_restart, &
                          Ice_bc_restart, Time, Time_start, Time_end, Time_restart_current)
@@ -1349,7 +1349,7 @@ contains
   end subroutine coupler_restart
 
 !--------------------------------------------------------------------------
-  
+
 !> \brief Print out checksums for several atm, land and ice variables
   subroutine coupler_chksum(id, timestep, Atm, Land, Ice)
 
@@ -1922,8 +1922,8 @@ contains
   subroutine coupler_atmos_tracer_driver_gather_data(Atm, coupler_clocks)
 
     implicit none
-    
-    type(atmos_data_type), intent(inout)    :: Atm !< Atm 
+
+    type(atmos_data_type), intent(inout)    :: Atm !< Atm
     type(coupler_clock_type), intent(inout) :: coupler_clocks !< coupler_clocks
     call fms_mpp_clock_begin(coupler_clocks%atmos_tracer_driver_gather_data)
     call atmos_tracer_driver_gather_data(Atm%fields, Atm%tr_bot)
@@ -1945,16 +1945,16 @@ contains
     integer, intent(in)            :: current_timestep !< (nc-1)*num_atmos_cal + na
     type(coupler_chksum_type), intent(in)   :: coupler_chksum_obj
     type(coupler_clock_type), intent(inout) :: coupler_clocks !< coupler_clocks
-                                                                                
+
     call fms_mpp_clock_begin(coupler_clocks%sfc_boundary_layer)
 
     call sfc_boundary_layer( real(dt_atmos), Time_atmos, Atm, Land, Ice, Land_ice_atmos_boundary )
     if (do_chksum)  call atmos_ice_land_chksum('sfc+', current_timestep, Atm, Land, Ice, &
         Land_ice_atmos_boundary, coupler_chksum_obj%Atmos_ice_boundary,                  &
         coupler_chksum_obj%Atmos_land_boundary)
-    
+
     call fms_mpp_clock_end(coupler_clocks%sfc_boundary_layer)
-    
+
   end subroutine coupler_sfc_boundary_layer
 
   !> This subroutine calls update_atmos_model_dynamics.  Clocks are set for runtime statistics.  Chksums
@@ -1963,10 +1963,10 @@ contains
 
     implicit none
     type(atmos_data_type), intent(inout) :: Atm !< Atm
-    integer,                   intent(in) :: current_timestep   !< Current timestep 
+    integer,                   intent(in) :: current_timestep   !< Current timestep
     type(coupler_chksum_type), intent(in) :: coupler_chksum_obj !< coupler_chksum_obj pointing to component types
     type(coupler_clock_type),  intent(inout) :: coupler_clocks  !< coupler_clocks
-    
+
     call fms_mpp_clock_begin(coupler_clocks%update_atmos_model_dynamics)
     call update_atmos_model_dynamics(Atm)
     call fms_mpp_clock_end(coupler_clocks%update_atmos_model_dynamics)
@@ -1976,7 +1976,7 @@ contains
         coupler_chksum_obj%Atmos_ice_boundary, coupler_chksum_obj%Atmos_land_boundary)
 
     if (do_debug)  call fms_memutils_print_memuse_stats( 'update dyn')
-    
+
   end subroutine coupler_update_atmos_model_dynamics
 
   !> This subroutine calls update_atmos_model_radiation.  Clocks are set for runtime statistics.
@@ -1990,11 +1990,11 @@ contains
     type(atmos_data_type), intent(inout) :: Atm
     type(land_ice_atmos_boundary_type), intent(inout) :: Land_ice_atmos_boundary
     type(coupler_clock_type),         intent(inout) :: coupler_clocks     !< coupler_clocks
-    integer,                   optional, intent(in) :: current_timestep   !< Current timestep 
+    integer,                   optional, intent(in) :: current_timestep   !< Current timestep
     type(coupler_chksum_type), optional, intent(in) :: coupler_chksum_obj !< points to component types
 
     character(128) :: memuse_stats_id = 'update serial rad'
-    
+
     call fms_mpp_clock_begin(coupler_clocks%radiation)
     call update_atmos_model_radiation( Land_ice_atmos_boundary, Atm )
     call fms_mpp_clock_end(coupler_clocks%radiation)
@@ -2006,7 +2006,7 @@ contains
                                        Atm, coupler_chksum_obj%Land, coupler_chksum_obj%Ice, Land_ice_atmos_boundary,  &
                                        coupler_chksum_obj%Atmos_ice_boundary, coupler_chksum_obj%Atmos_land_boundary)
     end if
-    
+
     if (do_debug) then
       if(do_concurrent_radiation) memuse_stats_id = 'update concurrent rad'
       call fms_memutils_print_memuse_stats(trim(memuse_stats_id))
@@ -2022,7 +2022,7 @@ contains
     implicit none
     type(atmos_data_type), intent(inout) :: Atm  !< Atm
     type(land_ice_atmos_boundary_type), intent(inout) :: Land_ice_atmos_boundary !<Land ice_atmos_boundary
-    integer,                   intent(in) :: current_timestep   !< Current timestep 
+    integer,                   intent(in) :: current_timestep   !< Current timestep
     type(coupler_chksum_type), intent(in) :: coupler_chksum_obj !< coupler_chksum_obj pointing to component types
     type(coupler_clock_type),  intent(inout) :: coupler_clocks  !< coupler_clocks
 
@@ -2053,7 +2053,7 @@ contains
     type(FmsTime_type), intent(in) :: Time_atmos       !<Time_atmos FmsTime_type containing time in seconds
     integer,            intent(in) :: current_timestep !< current_timestep
     type(coupler_clock_type), intent(inout) :: coupler_clocks !<coupler_clocks
-    
+
     call fms_mpp_clock_begin(coupler_clocks%flux_down_from_atmos)
     call flux_down_from_atmos(Time_atmos, Atm, Land, Ice, Land_ice_atmos_boundary, &
                               Atmos_land_boundary, Atmos_ice_boundary )
@@ -2061,7 +2061,7 @@ contains
 
     if (do_chksum) call atmos_ice_land_chksum('flux_down_from_atmos+', current_timestep, Atm, Land, &
                    Ice, Land_ice_atmos_boundary, Atmos_ice_boundary, Atmos_land_boundary)
-          
+
   end subroutine coupler_flux_down_from_atmos
 
   !> This subroutine calls update_land_model_fast.  Clocks are set for runtime statistics.  Chksums
@@ -2079,17 +2079,17 @@ contains
 
     call fms_mpp_clock_begin(coupler_clocks%update_land_model_fast) !< current pelist=Atm%pelist
     if (land_npes .NE. atmos_npes) call fms_mpp_set_current_pelist(Land%pelist)
-    
+
     call update_land_model_fast( Atmos_land_boundary, Land )
 
     if (land_npes .NE. atmos_npes) call fms_mpp_set_current_pelist(atm_pelist)
     call fms_mpp_clock_end(coupler_clocks%update_land_model_fast)
-    
+
     if (do_chksum) call atmos_ice_land_chksum('update_land_fast+', current_timestep, coupler_chksum_obj%Atm, Land, &
         coupler_chksum_obj%Ice, coupler_chksum_obj%Land_ice_atmos_boundary, coupler_chksum_obj%Atmos_ice_boundary, &
         coupler_chksum_obj%Atmos_land_boundary)
     if (do_debug)  call fms_memutils_print_memuse_stats( 'update land')
-    
+
   end subroutine coupler_update_land_model_fast
 
   !> This subroutine calls update_ice_model_fast.  Clocks are set for runtime statistics.  Chksums
@@ -2109,7 +2109,7 @@ contains
     if (ice_npes .NE. atmos_npes)call fms_mpp_set_current_pelist(Ice%fast_pelist)
 
     call update_ice_model_fast( Atmos_ice_boundary, Ice )
-    
+
     if (ice_npes .NE. atmos_npes) call fms_mpp_set_current_pelist(atm_pelist)
     call fms_mpp_clock_end(coupler_clocks%update_ice_model_fast)
 
@@ -2124,7 +2124,7 @@ contains
   !! are computed if do_chksum is .True.
   subroutine coupler_flux_up_to_atmos(Land, Ice, Land_ice_atmos_boundary, Atmos_land_boundary, Atmos_ice_boundary,&
                                       Time_atmos, current_timestep, coupler_chksum_obj, coupler_clocks)
-    
+
     implicit none
     type(land_data_type), intent(inout) :: Land !< Land
     type(ice_data_type),  intent(inout) :: Ice  !< Ice
@@ -2141,8 +2141,8 @@ contains
     call fms_mpp_clock_end(coupler_clocks%flux_up_to_atmos)
 
     if (do_chksum) call atmos_ice_land_chksum('flux_up2atmos+', current_timestep, coupler_chksum_obj%Atm, &
-                   Land, Ice, Land_ice_atmos_boundary, Atmos_ice_boundary, Atmos_land_boundary)   
-    
+                   Land, Ice, Land_ice_atmos_boundary, Atmos_ice_boundary, Atmos_land_boundary)
+
   end subroutine coupler_flux_up_to_atmos
 
   !> This subroutine calls update_atmos_model_up.  Clocks are set for runtime statistics.  Chksums
@@ -2156,7 +2156,7 @@ contains
     integer,                  intent(in) :: current_timestep   !< current_timestep
     type(coupler_chksum_type),intent(in) :: coupler_chksum_obj !< points to component types
     type(coupler_clock_type), intent(inout) :: coupler_clocks  !< coupler_clocks
-    
+
     call fms_mpp_clock_begin(coupler_clocks%update_atmos_model_up)
     call update_atmos_model_up(Land_ice_atmos_boundary, Atm)
     call fms_mpp_clock_end(coupler_clocks%update_atmos_model_up)
@@ -2164,8 +2164,8 @@ contains
     if (do_chksum) call atmos_ice_land_chksum('update_atmos_up+', current_timestep, Atm, coupler_chksum_obj%Land, &
                    coupler_chksum_obj%Ice, Land_ice_atmos_boundary, &
                    coupler_chksum_obj%Atmos_ice_boundary, coupler_chksum_obj%Atmos_land_boundary)
-    if (do_debug) call fms_memutils_print_memuse_stats( 'update up')    
-    
+    if (do_debug) call fms_memutils_print_memuse_stats( 'update up')
+
   end subroutine coupler_update_atmos_model_up
 
   !> This subroutine calls flux_atmos_to_ocean and calls flux_ex_arrays_dealloc
@@ -2179,7 +2179,7 @@ contains
 
     call flux_atmos_to_ocean(Time_atmos, Atm, Atmos_ice_boundary, Ice)
     call flux_ex_arrays_dealloc
-    
+
   end subroutine coupler_flux_atmos_to_ocean
 
   subroutine coupler_update_atmos_model_state(Atm, current_timestep, coupler_chksum_obj, coupler_clocks)
@@ -2193,12 +2193,12 @@ contains
     call fms_mpp_clock_begin(coupler_clocks%update_atmos_model_state)
     call update_atmos_model_state( Atm )
     call fms_mpp_clock_end(coupler_clocks%update_atmos_model_state)
-    
+
     if (do_chksum) call atmos_ice_land_chksum('update_atmos_model_state+', current_timestep, Atm,    &
                    coupler_chksum_obj%Land, coupler_chksum_obj%Ice, coupler_chksum_obj%Land_ice_atmos_boundary, &
                    coupler_chksum_obj%Atmos_ice_boundary, coupler_chksum_obj%Atmos_land_boundary)
     if (do_debug)  call fms_memutils_print_memuse_stats( 'update state')
-    
+
   end subroutine coupler_update_atmos_model_state
-  
+
 end module full_coupler_mod

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -2226,13 +2226,15 @@ contains
 
   end subroutine coupler_flux_atmos_to_ocean
 
+  !> This subroutine calls update_atmos_model_state.  Chksums are mem usage are computed
+  !! if do_chksum and do_debug are .True. respectively
   subroutine coupler_update_atmos_model_state(Atm, current_timestep, coupler_chksum_obj, coupler_clocks)
 
     implicit none
-    type(atmos_data_type), intent(inout) :: Atm
-    integer,               intent(in)     :: current_timestep
-    type(coupler_chksum_type), intent(in)    :: coupler_chksum_obj
-    type(coupler_clock_type),  intent(inout) :: coupler_clocks
+    type(atmos_data_type), intent(inout)  :: Atm               !< Atm
+    integer,               intent(in)     :: current_timestep  !< current_timestep
+    type(coupler_chksum_type), intent(in)    :: coupler_chksum_obj !< used to compute chksums
+    type(coupler_clock_type),  intent(inout) :: coupler_clocks     !< coupler_clocks
 
     call fms_mpp_clock_begin(coupler_clocks%update_atmos_model_state)
     call update_atmos_model_state( Atm )

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -132,7 +132,7 @@ module full_coupler_mod
 
   public :: coupler_generate_sfc_xgrid
   public :: coupler_atmos_tracer_driver_gather_data, coupler_sfc_boundary_layer
-  
+
   public :: coupler_clock_type, coupler_chksum_type
 
 #include <file_version.fh>
@@ -276,9 +276,9 @@ module full_coupler_mod
     integer :: ocean_model_init
     integer :: flux_exchange_init
   end type coupler_clock_type
-  
+
   type coupler_chksum_type
-    type(atmos_data_type), pointer :: Atm    
+    type(atmos_data_type), pointer :: Atm
     type(land_data_type),  pointer :: Land
     type(ice_data_type),   pointer :: Ice
     type(ocean_public_type), pointer :: Ocean
@@ -291,7 +291,7 @@ module full_coupler_mod
   contains
     procedure :: coupler_chksum_obj_init
   end type coupler_chksum_type
-  
+
   character(len=80) :: text
   character(len=48), parameter :: mod_name = 'coupler_main_mod'
 
@@ -1149,7 +1149,7 @@ contains
     type(land_ice_boundary_type),   target, intent(in) :: Land_ice_boundary
     type(ice_ocean_boundary_type),  target, intent(in) :: Ice_ocean_boundary
     type(ocean_ice_boundary_type),  target, intent(in) :: Ocean_ice_boundary
-    
+
     self%Atm => Atm
     self%Land => Land
     self%Ice => Ice
@@ -1159,11 +1159,11 @@ contains
     self%Atmos_ice_boundary => Atmos_ice_boundary
     self%Land_ice_boundary => Land_ice_boundary
     self%Ice_ocean_boundary => Ice_ocean_boundary
-    self%Ocean_ice_boundary => Ocean_ice_boundary   
+    self%Ocean_ice_boundary => Ocean_ice_boundary
 
   end subroutine coupler_chksum_obj_init
 
-  
+
   subroutine coupler_end(Atm, Land, Ice, Ocean, Ocean_state, Land_ice_atmos_boundary, Atmos_ice_boundary,&
                          Atmos_land_boundary, Ice_ocean_boundary, Ocean_ice_boundary, Ocn_bc_restart, &
                          Ice_bc_restart, Time, Time_start, Time_end, Time_restart_current)
@@ -1350,7 +1350,7 @@ contains
   end subroutine coupler_restart
 
 !--------------------------------------------------------------------------
-  
+
 !> \brief Print out checksums for several atm, land and ice variables
   subroutine coupler_chksum(id, timestep, Atm, Land, Ice)
 
@@ -1923,8 +1923,8 @@ contains
   subroutine coupler_atmos_tracer_driver_gather_data(Atm, coupler_clocks)
 
     implicit none
-    
-    type(atmos_data_type), intent(inout)    :: Atm !< Atm 
+
+    type(atmos_data_type), intent(inout)    :: Atm !< Atm
     type(coupler_clock_type), intent(inout) :: coupler_clocks !< coupler_clocks
     call fms_mpp_clock_begin(coupler_clocks%atmos_tracer_driver_gather_data)
     call atmos_tracer_driver_gather_data(Atm%fields, Atm%tr_bot)
@@ -1946,17 +1946,17 @@ contains
     integer, intent(in)            :: current_time_step    !< (nc-1)*num_atmos_cal + na
     type(coupler_chksum_type), intent(in)   :: coupler_chksum_obj
     type(coupler_clock_type), intent(inout) :: coupler_clocks !< coupler_clocks
-                                                                                
+
     call fms_mpp_clock_begin(coupler_clocks%sfc_boundary_layer)
 
     call sfc_boundary_layer( real(dt_atmos), Time_atmos, Atm, Land, Ice, Land_ice_atmos_boundary )
     call atmos_ice_land_chksum('sfc+', current_time_step, Atm, Land, Ice, &
         Land_ice_atmos_boundary, coupler_chksum_obj%Atmos_ice_boundary,                   &
         coupler_chksum_obj%Atmos_land_boundary)
-    
+
     call fms_mpp_clock_end(coupler_clocks%sfc_boundary_layer)
-    
+
   end subroutine coupler_sfc_boundary_layer
-  
-  
+
+
 end module full_coupler_mod

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -277,21 +277,24 @@ module full_coupler_mod
     integer :: flux_exchange_init
   end type coupler_clock_type
 
+  !> The purpose of objects of coupler_chksum_type is to simplify the list
+  !! of arguments required for chksum related subroutines in full_coupler_mod.
+  !! The members of this type point to the model components 
   type coupler_chksum_type
     private
-    type(atmos_data_type), pointer :: Atm
-    type(land_data_type),  pointer :: Land
-    type(ice_data_type),   pointer :: Ice
-    type(ocean_public_type), pointer :: Ocean
-    type(land_ice_atmos_boundary_type), pointer :: Land_ice_atmos_boundary
-    type(atmos_land_boundary_type), pointer :: Atmos_land_boundary
-    type(atmos_ice_boundary_type),  pointer :: Atmos_ice_boundary
-    type(land_ice_boundary_type),   pointer :: Land_ice_boundary
-    type(ice_ocean_boundary_type),  pointer :: Ice_ocean_boundary
-    type(ocean_ice_boundary_type),  pointer :: Ocean_ice_boundary
+    type(atmos_data_type), pointer :: Atm  !< pointer to Atm 
+    type(land_data_type),  pointer :: Land !< pointer to Land
+    type(ice_data_type),   pointer :: Ice  !< pointer to Ice
+    type(ocean_public_type), pointer :: Ocean  !< pointer to Ocean
+    type(land_ice_atmos_boundary_type), pointer :: Land_ice_atmos_boundary !< pointer to Land_ice_atmos_boundary
+    type(atmos_land_boundary_type), pointer :: Atmos_land_boundary !< pointer to Atmos_land_boundary
+    type(atmos_ice_boundary_type),  pointer :: Atmos_ice_boundary  !< pointer to Atmos_ice_boundary
+    type(land_ice_boundary_type),   pointer :: Land_ice_boundary   !< pointer to Land_ice_boundary
+    type(ice_ocean_boundary_type),  pointer :: Ice_ocean_boundary  !< pointer to Ice_ocean_boundary
+    type(ocean_ice_boundary_type),  pointer :: Ocean_ice_boundary  !< pointer to Ocean_ice_boundary
   contains
-    procedure, public :: coupler_chksum_obj_init
-    procedure, public :: get_component
+    procedure, public :: coupler_chksum_obj_init !< associates the pointers above to model components
+    procedure, public :: get_component  !< subroutine to retrieve the requested component of an object of this type
   end type coupler_chksum_type
 
   character(len=80) :: text
@@ -1134,21 +1137,23 @@ contains
   end subroutine coupler_init
 
 !#######################################################################
+
+  !> This subroutine associates the pointer in an object of coupler_chksum_type to the component models 
   subroutine coupler_chksum_obj_init(this, Atm, Land, Ice, Ocean, Land_ice_atmos_boundary, Atmos_land_boundary, &
                                      Atmos_ice_boundary, Land_ice_boundary, Ice_ocean_boundary, Ocean_ice_boundary)
 
     implicit none
-    class(coupler_chksum_type), intent(inout) :: this
-    type(atmos_data_type), target, intent(in) :: Atm
-    type(land_data_type),  target, intent(in) :: Land
-    type(ice_data_type),   target, intent(in) :: Ice
-    type(ocean_public_type), target, intent(in) :: Ocean
-    type(land_ice_atmos_boundary_type), target, intent(in) :: Land_ice_atmos_boundary
-    type(atmos_land_boundary_type), target, intent(in) :: Atmos_land_boundary
-    type(atmos_ice_boundary_type),  target, intent(in) :: Atmos_ice_boundary
-    type(land_ice_boundary_type),   target, intent(in) :: Land_ice_boundary
-    type(ice_ocean_boundary_type),  target, intent(in) :: Ice_ocean_boundary
-    type(ocean_ice_boundary_type),  target, intent(in) :: Ocean_ice_boundary
+    class(coupler_chksum_type), intent(inout) :: this !< self
+    type(atmos_data_type), target, intent(in) :: Atm  !< Atm
+    type(land_data_type),  target, intent(in) :: Land !< Land
+    type(ice_data_type),   target, intent(in) :: Ice  !< Ice
+    type(ocean_public_type), target, intent(in) :: Ocean !< Ocean
+    type(land_ice_atmos_boundary_type), target, intent(in) :: Land_ice_atmos_boundary !< Land_ice_atmos_boundary
+    type(atmos_land_boundary_type), target, intent(in) :: Atmos_land_boundary !< Atmos_land_boundary
+    type(atmos_ice_boundary_type),  target, intent(in) :: Atmos_ice_boundary  !< Atmos_ice_boundary
+    type(land_ice_boundary_type),   target, intent(in) :: Land_ice_boundary   !< Land_ice_boundary
+    type(ice_ocean_boundary_type),  target, intent(in) :: Ice_ocean_boundary  !< Ice_ocean_boundary
+    type(ocean_ice_boundary_type),  target, intent(in) :: Ocean_ice_boundary  !< Ocean_ice_boundary
 
     this%Atm => Atm
     this%Land => Land

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -289,7 +289,6 @@ module full_coupler_mod
   contains
     procedure, public :: initialize_coupler_components_obj
     procedure, public :: get_component  !< subroutine to retrieve the requested component of an object of this type
-    procedure, public :: set_component  !< subroutine to set requested component of an object of this type
   end type coupler_components_type
 
   !> The purpose of objects of coupler_chksum_type is to simplify the list
@@ -301,7 +300,6 @@ module full_coupler_mod
   contains
     procedure, public :: initialize_coupler_chksum_obj !< associates the pointers above to model components
     procedure, public :: get_components_obj !< subroutine to retrieve the requested component of an object of this type
-    procedure, public :: set_components_obj !< subroutine to set components object
     procedure, public :: get_atmos_ice_land_ocean_chksums !< subroutine to compute chksums for atmos - ocean
     procedure, public :: get_atmos_ice_land_chksums !< subroutine to compute chksums for atmos_ice_land
     procedure, public :: get_slow_ice_chksums       !< subroutine to compute chskums for slow_ice
@@ -1216,37 +1214,6 @@ contains
 
   end subroutine get_component
 
-  !> Function set_component sets the requested component in the coupler_components_type object
-  !! Users are required to provide the component to be set as an input argument.  For example,
-  !! coupler_components_obj%get_component(Atm) will set coupler_components_obj%Atm = Atm
-  subroutine set_component(this, set_this_component )
-
-    implicit none
-    class(coupler_components_type), intent(inout) :: this !< the coupler_components_type object
-    class(*), intent(in) :: set_this_component  !< requested component to be be set.
-                            !! set_this_component can be of type atmos_data_type, land_data_type, ice_data_type,
-                            !! ocean_public_type, land_ice_atmos_boundary_type, atmos_land_boundary_type,
-                            !! atmos_ice_boundary_type, land_ice_boundary_type, ice_ocean_boundary_type,
-                            !! ocean_ice_boundary_type
-
-    select type(set_this_component)
-    type is(atmos_data_type)   ; this%Atm  = set_this_component
-    type is(land_data_type)    ; this%Land = set_this_component
-    type is(ice_data_type)     ; this%Ice  = set_this_component
-    type is(ocean_public_type) ; this%Ocean = set_this_component
-    type is(land_ice_atmos_boundary_type) ; this%Land_ice_atmos_boundary = set_this_component
-    type is(atmos_land_boundary_type) ; this%Atmos_land_boundary = set_this_component
-    type is(atmos_ice_boundary_type)  ; this%Atmos_ice_boundary = set_this_component
-    type is(land_ice_boundary_type)   ; this%Land_ice_boundary  = set_this_component
-    type is(ice_ocean_boundary_type)  ; this%Ice_ocean_boundary = set_this_component
-    type is(ocean_ice_boundary_type)  ; this%Ocean_ice_boundary = set_this_component
-    class default
-      call fms_mpp_error(FATAL, "failure setting component in coupler_components_type object, &
-                         cannot recognize the type of requested component")
-    end select
-
-  end subroutine set_component
-
   !> This subroutine associates the pointer in an object of coupler_chksum_type to the component models
   subroutine initialize_coupler_chksum_obj(this, components_obj)
 
@@ -1269,18 +1236,6 @@ contains
     components_obj = this%components
 
   end subroutine get_components_obj
-
-  !> This subroutine set coupler_chksum_obj%components_obj
-  subroutine set_components_obj(this, components_obj)
-
-    implicit none
-
-    class(coupler_chksum_type), intent(inout) :: this  !< coupler_chksum_type
-    type(coupler_components_type), intent(in) :: components_obj !< coupler_components_type to be used
-
-    this%components = components_obj
-
-  end subroutine set_components_obj
 
   !> This subroutine finalizes the run
   subroutine coupler_end(Atm, Land, Ice, Ocean, Ocean_state, Land_ice_atmos_boundary, Atmos_ice_boundary,&

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -276,9 +276,9 @@ module full_coupler_mod
     integer :: ocean_model_init
     integer :: flux_exchange_init
   end type coupler_clock_type
-  
+
   type coupler_chksum_type
-    type(atmos_data_type), pointer :: Atm    
+    type(atmos_data_type), pointer :: Atm
     type(land_data_type),  pointer :: Land
     type(ice_data_type),   pointer :: Ice
     type(ocean_public_type), pointer :: Ocean
@@ -291,7 +291,7 @@ module full_coupler_mod
   contains
     procedure :: coupler_chksum_obj_init
   end type coupler_chksum_type
-  
+
   character(len=80) :: text
   character(len=48), parameter :: mod_name = 'coupler_main_mod'
 
@@ -1148,7 +1148,7 @@ contains
     type(land_ice_boundary_type),   target, intent(in) :: Land_ice_boundary
     type(ice_ocean_boundary_type),  target, intent(in) :: Ice_ocean_boundary
     type(ocean_ice_boundary_type),  target, intent(in) :: Ocean_ice_boundary
-    
+
     self%Atm => Atm
     self%Land => Land
     self%Ice => Ice
@@ -1158,11 +1158,11 @@ contains
     self%Atmos_ice_boundary => Atmos_ice_boundary
     self%Land_ice_boundary => Land_ice_boundary
     self%Ice_ocean_boundary => Ice_ocean_boundary
-    self%Ocean_ice_boundary => Ocean_ice_boundary   
+    self%Ocean_ice_boundary => Ocean_ice_boundary
 
   end subroutine coupler_chksum_obj_init
 
-  
+
   subroutine coupler_end(Atm, Land, Ice, Ocean, Ocean_state, Land_ice_atmos_boundary, Atmos_ice_boundary,&
                          Atmos_land_boundary, Ice_ocean_boundary, Ocean_ice_boundary, Ocn_bc_restart, &
                          Ice_bc_restart, Time, Time_start, Time_end, Time_restart_current)
@@ -1349,7 +1349,7 @@ contains
   end subroutine coupler_restart
 
 !--------------------------------------------------------------------------
-  
+
 !> \brief Print out checksums for several atm, land and ice variables
   subroutine coupler_chksum(id, timestep, Atm, Land, Ice)
 
@@ -1922,8 +1922,8 @@ contains
   subroutine coupler_atmos_tracer_driver_gather_data(Atm, coupler_clocks)
 
     implicit none
-    
-    type(atmos_data_type), intent(inout)    :: Atm !< Atm 
+
+    type(atmos_data_type), intent(inout)    :: Atm !< Atm
     type(coupler_clock_type), intent(inout) :: coupler_clocks !< coupler_clocks
     call fms_mpp_clock_begin(coupler_clocks%atmos_tracer_driver_gather_data)
     call atmos_tracer_driver_gather_data(Atm%fields, Atm%tr_bot)
@@ -1945,16 +1945,16 @@ contains
     integer, intent(in)            :: current_timestep !< (nc-1)*num_atmos_cal + na
     type(coupler_chksum_type), intent(in)   :: coupler_chksum_obj
     type(coupler_clock_type), intent(inout) :: coupler_clocks !< coupler_clocks
-                                                                                
+
     call fms_mpp_clock_begin(coupler_clocks%sfc_boundary_layer)
 
     call sfc_boundary_layer( real(dt_atmos), Time_atmos, Atm, Land, Ice, Land_ice_atmos_boundary )
     if (do_chksum)  call atmos_ice_land_chksum('sfc+', current_timestep, Atm, Land, Ice, &
         Land_ice_atmos_boundary, coupler_chksum_obj%Atmos_ice_boundary,                  &
         coupler_chksum_obj%Atmos_land_boundary)
-    
+
     call fms_mpp_clock_end(coupler_clocks%sfc_boundary_layer)
-    
+
   end subroutine coupler_sfc_boundary_layer
 
   !> This subroutine calls update_atmos_model_dynamics.  Clocks are set for runtime statistics.  Chksums
@@ -1963,10 +1963,10 @@ contains
 
     implicit none
     type(atmos_data_type), intent(inout) :: Atm !< Atm
-    integer,                   intent(in) :: current_timestep   !< Current timestep 
+    integer,                   intent(in) :: current_timestep   !< Current timestep
     type(coupler_chksum_type), intent(in) :: coupler_chksum_obj !< coupler_chksum_obj pointing to component types
     type(coupler_clock_type),  intent(inout) :: coupler_clocks  !< coupler_clocks
-    
+
     call fms_mpp_clock_begin(coupler_clocks%update_atmos_model_dynamics)
     call update_atmos_model_dynamics(Atm)
     call fms_mpp_clock_end(coupler_clocks%update_atmos_model_dynamics)
@@ -1976,7 +1976,7 @@ contains
         coupler_chksum_obj%Atmos_ice_boundary, coupler_chksum_obj%Atmos_land_boundary)
 
     if (do_debug)  call fms_memutils_print_memuse_stats( 'update dyn')
-    
+
   end subroutine coupler_update_atmos_model_dynamics
 
   !> This subroutine calls update_atmos_model_radiation.  Clocks are set for runtime statistics.
@@ -1990,11 +1990,11 @@ contains
     type(atmos_data_type), intent(inout) :: Atm
     type(land_ice_atmos_boundary_type), intent(inout) :: Land_ice_atmos_boundary
     type(coupler_clock_type),         intent(inout) :: coupler_clocks     !< coupler_clocks
-    integer,                   optional, intent(in) :: current_timestep   !< Current timestep 
+    integer,                   optional, intent(in) :: current_timestep   !< Current timestep
     type(coupler_chksum_type), optional, intent(in) :: coupler_chksum_obj !< points to component types
 
     character(128) :: memuse_stats_id = 'update serial rad'
-    
+
     call fms_mpp_clock_begin(coupler_clocks%radiation)
     call update_atmos_model_radiation( Land_ice_atmos_boundary, Atm )
     call fms_mpp_clock_end(coupler_clocks%radiation)
@@ -2006,7 +2006,7 @@ contains
                                        Atm, coupler_chksum_obj%Land, coupler_chksum_obj%Ice, Land_ice_atmos_boundary,  &
                                        coupler_chksum_obj%Atmos_ice_boundary, coupler_chksum_obj%Atmos_land_boundary)
     end if
-    
+
     if (do_debug) then
       if(do_concurrent_radiation) memuse_stats_id = 'update concurrent rad'
       call fms_memutils_print_memuse_stats(trim(memuse_stats_id))
@@ -2022,7 +2022,7 @@ contains
     implicit none
     type(atmos_data_type), intent(inout) :: Atm  !< Atm
     type(land_ice_atmos_boundary_type), intent(inout) :: Land_ice_atmos_boundary !<Land ice_atmos_boundary
-    integer,                   intent(in) :: current_timestep   !< Current timestep 
+    integer,                   intent(in) :: current_timestep   !< Current timestep
     type(coupler_chksum_type), intent(in) :: coupler_chksum_obj !< coupler_chksum_obj pointing to component types
     type(coupler_clock_type),  intent(inout) :: coupler_clocks  !< coupler_clocks
 
@@ -2053,7 +2053,7 @@ contains
     type(FmsTime_type), intent(in) :: Time_atmos       !<Time_atmos FmsTime_type containing time in seconds
     integer,            intent(in) :: current_timestep !< current_timestep
     type(coupler_clock_type), intent(inout) :: coupler_clocks !<coupler_clocks
-    
+
     call fms_mpp_clock_begin(coupler_clocks%flux_down_from_atmos)
     call flux_down_from_atmos(Time_atmos, Atm, Land, Ice, Land_ice_atmos_boundary, &
                               Atmos_land_boundary, Atmos_ice_boundary )
@@ -2061,7 +2061,7 @@ contains
 
     if (do_chksum) call atmos_ice_land_chksum('flux_down_from_atmos+', current_timestep, Atm, Land, &
                    Ice, Land_ice_atmos_boundary, Atmos_ice_boundary, Atmos_land_boundary)
-          
+
   end subroutine coupler_flux_down_from_atmos
-  
+
 end module full_coupler_mod

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -331,8 +331,8 @@ contains
     integer, allocatable, dimension(:,:), intent(inout) :: ensemble_pelist
     integer, allocatable, dimension(:),   intent(inout) :: slow_ice_ocean_pelist
 
-    type(coupler_clock_type) :: coupler_clocks
-    type(coupler_chksum_type) :: coupler_chksum_obj
+    type(coupler_clock_type), intent(inout)  :: coupler_clocks
+    type(coupler_chksum_type), intent(inout) :: coupler_chksum_obj
 
     type(FMSTime_type), intent(inout) :: Time_step_cpld, Time_step_atmos, Time_atmos, Time_ocean
     type(FMSTime_type), intent(inout) :: Time, Time_start, Time_end, Time_restart, Time_restart_current

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -2067,11 +2067,13 @@ contains
 
   !> This subroutine calls update_land_model_fast.  Clocks are set for runtime statistics.  Chksums
   !! and memory usage are computed if do_chksum and do_debug are .True.
-  subroutine coupler_update_land_model_fast(Land, Atmos_land_boundary, current_timestep, coupler_chksum_obj, coupler_clocks)
+  subroutine coupler_update_land_model_fast(Land, Atmos_land_boundary, atm_pelist, current_timestep, &
+                                            coupler_chksum_obj, coupler_clocks)
 
     implicit none
-    type(land_data_type),      intent(inout) :: Land                !< Land
-    type(atmos_land_boundary), intent(inout) :: Atmos_land_boundary !< Atmos_land_boundary
+    type(land_data_type),           intent(inout) :: Land !< Land
+    type(atmos_land_boundary_type), intent(inout) :: Atmos_land_boundary !< Atmos_land_boundary
+    integer, dimension(:), intent(in) :: atm_pelist !< Atm%pelist to reset the pelist to Atm%pelist
     integer,                   intent(in) :: current_timestep       !< current timestep
     type(coupler_chksum_type), intent(in) :: coupler_chksum_obj     !< points to component types
     type(coupler_clock_type),  intent(inout) :: coupler_clocks      !< coupler_clocks
@@ -2081,7 +2083,7 @@ contains
     
     call update_land_model_fast( Atmos_land_boundary, Land )
 
-    if (land_npes .NE. atmos_npes) call fms_mpp_set_current_pelist(Atm%pelist)
+    if (land_npes .NE. atmos_npes) call fms_mpp_set_current_pelist(atm_pelist)
     call fms_mpp_clock_end(coupler_clocks%update_land_model_fast)
     
     if (do_chksum) call atmos_ice_land_chksum('update_land_fast+', current_timestep, coupler_chksum_obj%Atm, Land, &
@@ -2093,11 +2095,13 @@ contains
 
   !> This subroutine calls update_ice_model_fast.  Clocks are set for runtime statistics.  Chksums
   !! and memory usage are computed if do_chksum and do_debug are .True.
-  subroutine coupler_update_ice_model_fast(Ice, Atmos_ice_boundary, current_timestep, coupler_chksum_obj, coupler_clocks)
+  subroutine coupler_update_ice_model_fast(Ice, Atmos_ice_boundary, atm_pelist, current_timestep, &
+                                           coupler_chksum_obj, coupler_clocks)
 
     implicit none
-    type(ice_data_type),      intent(inout) :: Ice                !< Ice
-    type(Atmos_ice_boundary), intent(inout) :: Atmos_ice_boundary !< Atmos_ice_boundary
+    type(ice_data_type),           intent(inout) :: Ice                !< Ice
+    type(Atmos_ice_boundary_type), intent(inout) :: Atmos_ice_boundary !< Atmos_ice_boundary
+    integer, dimension(:), intent(in) :: atm_pelist !< Atm%pelist to reset the pelist to Atm%pelist
     integer,                     intent(in) :: current_timestep   !< current_timestep
     type(coupler_chksum_type),   intent(in) :: coupler_chksum_obj !< points to component types
     type(coupler_clock_type), intent(inout) :: coupler_clocks     !< coupler_clocks
@@ -2107,7 +2111,7 @@ contains
 
     call update_ice_model_fast( Atmos_ice_boundary, Ice )
     
-    if (ice_npes .NE. atmos_npes) call fms_mpp_set_current_pelist(Atm%pelist)
+    if (ice_npes .NE. atmos_npes) call fms_mpp_set_current_pelist(atm_pelist)
     call fms_mpp_clock_end(coupler_clocks%update_ice_model_fast)
 
     if (do_chksum) call atmos_ice_land_chksum('update_ice_fast+', current_timestep, coupler_chksum_obj%Atm,&
@@ -2148,8 +2152,8 @@ contains
                                            coupler_chksum_obj, coupler_clocks)
 
     implicit none
-    type(atmos_data_type),         intent(inout) :: Atm                     !< Atm
-    type(land_ice_atmos_boundary), intent(inout) :: Land_ice_atmos_boundary  !< Land_ice_atmos_boundary
+    type(atmos_data_type),              intent(inout) :: Atm                      !< Atm
+    type(land_ice_atmos_boundary_type), intent(inout) :: Land_ice_atmos_boundary  !< Land_ice_atmos_boundary
     integer,                  intent(in) :: current_timestep   !< current_timestep
     type(coupler_chksum_type),intent(in) :: coupler_chksum_obj !< points to component types
     type(coupler_clock_type), intent(inout) :: coupler_clocks  !< coupler_clocks

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -297,7 +297,7 @@ module full_coupler_mod
   !! The members of this type point to the model components
   type coupler_chksum_type
     private
-    type(coupler_components_type), pointer :: components
+    type(coupler_components_type) :: components
   contains
     procedure, public :: initialize_coupler_chksum_obj !< associates the pointers above to model components
     procedure, public :: get_components_obj !< subroutine to retrieve the requested component of an object of this type

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -1544,7 +1544,7 @@ contains
 
     call fms_mpp_set_current_pelist()
 
-  end subroutine get_coupler_atmos_ice_land_ocean_chksums
+  end subroutine get_atmos_ice_land_ocean_chksums
   
 !> \brief This subroutine calls subroutine that will print out checksums of the elements
 !! of the appropriate type.

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -1156,7 +1156,7 @@ contains
       Atmos_land_boundary, Atmos_ice_boundary, Land_ice_boundary, Ice_ocean_boundary, Ocean_ice_boundary)
 
     implicit none
-    class(coupler_chksum_type), intent(inout) :: self
+    class(coupler_chksum_type), intent(inout) :: this
     type(atmos_data_type), target, intent(in) :: Atm
     type(land_data_type),  target, intent(in) :: Land
     type(ice_data_type),   target, intent(in) :: Ice
@@ -1168,16 +1168,16 @@ contains
     type(ice_ocean_boundary_type),  target, intent(in) :: Ice_ocean_boundary
     type(ocean_ice_boundary_type),  target, intent(in) :: Ocean_ice_boundary
 
-    self%Atm => Atm
-    self%Land => Land
-    self%Ice => Ice
-    self%Ocean => Ocean
-    self%Land_ice_atmos_boundary => Land_ice_atmos_boundary
-    self%Atmos_land_boundary => Atmos_land_boundary
-    self%Atmos_ice_boundary => Atmos_ice_boundary
-    self%Land_ice_boundary => Land_ice_boundary
-    self%Ice_ocean_boundary => Ice_ocean_boundary
-    self%Ocean_ice_boundary => Ocean_ice_boundary
+    this%Atm => Atm
+    this%Land => Land
+    this%Ice => Ice
+    this%Ocean => Ocean
+    this%Land_ice_atmos_boundary => Land_ice_atmos_boundary
+    this%Atmos_land_boundary => Atmos_land_boundary
+    this%Atmos_ice_boundary => Atmos_ice_boundary
+    this%Land_ice_boundary => Land_ice_boundary
+    this%Ice_ocean_boundary => Ice_ocean_boundary
+    this%Ocean_ice_boundary => Ocean_ice_boundary
 
     this%Atm => Atm
     this%Land => Land

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -1889,10 +1889,10 @@ contains
     type(atmos_data_type), intent(inout) :: Atm  !< Atm
     type(land_data_type), intent(inout)  :: Land !< Land
     type(ice_data_type), intent(inout)   :: Ice  !< Ice
-    type(land_ice_atmos_boundary_type), intent(inout) :: Land_ice_atmos_boundary
-    type(atmos_ice_boundary_type), intent(inout) :: Atmos_ice_boundary  !<Required for chksum
-    type(atmo_land_boundary), intent(inout)      :: Atmos_land_boundary !<Required for chksum
-    type(FmsTimeType), intent(in) :: Time_atmos            !< Atmos time
+    type(land_ice_atmos_boundary_type), intent(inout) :: Land_ice_atmos_boundary !< Land_ice_atmos_boundary
+    type(atmos_ice_boundary_type), intent(inout)  :: Atmos_ice_boundary  !<Required for chksum
+    type(atmos_land_boundary_type), intent(inout) :: Atmos_land_boundary !<Required for chksum
+    type(FmsTime_type), intent(in) :: Time_atmos           !< Atmos time
     integer, intent(in)           :: current_time_step     !< (nc-1)*num_atmos_cal + na
     type(coupler_clock_type), intent(in) :: coupler_clocks !< coupler_clocks
                                                                                 

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -289,7 +289,6 @@ module full_coupler_mod
   contains
     procedure, public :: initialize_coupler_components_obj
     procedure, public :: get_component  !< subroutine to retrieve the requested component of an object of this type
-    procedure, public :: set_component  !< subroutine to set requested component of an object of this type
   end type coupler_components_type
 
   !> The purpose of objects of coupler_chksum_type is to simplify the list
@@ -297,11 +296,10 @@ module full_coupler_mod
   !! The members of this type point to the model components
   type coupler_chksum_type
     private
-    type(coupler_components_type) :: components
+    type(coupler_components_type), pointer :: components
   contains
     procedure, public :: initialize_coupler_chksum_obj !< associates the pointers above to model components
     procedure, public :: get_components_obj !< subroutine to retrieve the requested component of an object of this type
-    procedure, public :: set_components_obj !< subroutine to set components object
     procedure, public :: get_atmos_ice_land_ocean_chksums !< subroutine to compute chksums for atmos - ocean
     procedure, public :: get_atmos_ice_land_chksums !< subroutine to compute chksums for atmos_ice_land
     procedure, public :: get_slow_ice_chksums       !< subroutine to compute chskums for slow_ice
@@ -1214,45 +1212,14 @@ contains
 
   end subroutine get_component
 
-  !> Function set_component sets the requested component in the coupler_components_type object
-  !! Users are required to provide the component to be set as an input argument.  For example,
-  !! coupler_components_obj%get_component(Atm) will set coupler_components_obj%Atm = Atm
-  subroutine set_component(this, set_this_component )
-
-    implicit none
-    class(coupler_components_type), intent(inout) :: this !< the coupler_components_type object
-    class(*), intent(in) :: set_this_component  !< requested component to be be set.
-                            !! set_this_component can be of type atmos_data_type, land_data_type, ice_data_type,
-                            !! ocean_public_type, land_ice_atmos_boundary_type, atmos_land_boundary_type,
-                            !! atmos_ice_boundary_type, land_ice_boundary_type, ice_ocean_boundary_type,
-                            !! ocean_ice_boundary_type
-
-    select type(set_this_component)
-    type is(atmos_data_type)   ; this%Atm  = set_this_component
-    type is(land_data_type)    ; this%Land = set_this_component
-    type is(ice_data_type)     ; this%Ice  = set_this_component
-    type is(ocean_public_type) ; this%Ocean = set_this_component
-    type is(land_ice_atmos_boundary_type) ; this%Land_ice_atmos_boundary = set_this_component
-    type is(atmos_land_boundary_type) ; this%Atmos_land_boundary = set_this_component
-    type is(atmos_ice_boundary_type)  ; this%Atmos_ice_boundary = set_this_component
-    type is(land_ice_boundary_type)   ; this%Land_ice_boundary  = set_this_component
-    type is(ice_ocean_boundary_type)  ; this%Ice_ocean_boundary = set_this_component
-    type is(ocean_ice_boundary_type)  ; this%Ocean_ice_boundary = set_this_component
-    class default
-      call fms_mpp_error(FATAL, "failure setting component in coupler_components_type object, &
-                         cannot recognize the type of requested component")
-    end select
-
-  end subroutine set_component
-
   !> This subroutine associates the pointer in an object of coupler_chksum_type to the component models
   subroutine initialize_coupler_chksum_obj(this, components_obj)
 
     implicit none
     class(coupler_chksum_type), intent(inout) :: this
-    type(coupler_components_type), intent(in) :: components_obj
+    type(coupler_components_type), intent(in), target :: components_obj
 
-    this%components = components_obj
+    this%components => components_obj
 
   end subroutine initialize_coupler_chksum_obj
 
@@ -1267,18 +1234,6 @@ contains
     components_obj = this%components
 
   end subroutine get_components_obj
-
-  !> This subroutine set coupler_chksum_obj%components_obj
-  subroutine set_components_obj(this, components_obj)
-
-    implicit none
-
-    class(coupler_chksum_type), intent(inout) :: this  !< coupler_chksum_type
-    type(coupler_components_type), intent(in) :: components_obj !< coupler_components_type to be used
-
-    this%components = components_obj
-
-  end subroutine set_components_obj
 
   !> This subroutine finalizes the run
   subroutine coupler_end(Atm, Land, Ice, Ocean, Ocean_state, Land_ice_atmos_boundary, Atmos_ice_boundary,&

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -297,7 +297,7 @@ module full_coupler_mod
   !! The members of this type point to the model components
   type coupler_chksum_type
     private
-    type(coupler_components_type) :: components
+    type(coupler_components_type), pointer :: components
   contains
     procedure, public :: initialize_coupler_chksum_obj !< associates the pointers above to model components
     procedure, public :: get_components_obj !< subroutine to retrieve the requested component of an object of this type
@@ -1252,9 +1252,9 @@ contains
 
     implicit none
     class(coupler_chksum_type), intent(inout) :: this
-    type(coupler_components_type), intent(in) :: components_obj
+    type(coupler_components_type), target, intent(in) :: components_obj
 
-    this%components = components_obj
+    this%components => components_obj
 
   end subroutine initialize_coupler_chksum_obj
 

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -2154,7 +2154,7 @@ contains
     if (do_chksum) call coupler_chksum_obj%get_atmos_ice_land_chksums('update_ice_fast+', current_timestep)
     if (do_debug)  call fms_memutils_print_memuse_stats( 'update ice')
 
-  end subroutine
+  end subroutine coupler_update_ice_model_fast
 
   !> This subroutine calls flux_up_to_atmos.  Clocks are set for runtime statistics.  Chksums
   !! are computed if do_chksum is .True.

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -276,7 +276,7 @@ module full_coupler_mod
 
   type coupler_components_type
     private
-    type(atmos_data_type), pointer :: Atm  !< pointer to Atm 
+    type(atmos_data_type), pointer :: Atm  !< pointer to Atm
     type(land_data_type),  pointer :: Land !< pointer to Land
     type(ice_data_type),   pointer :: Ice  !< pointer to Ice
     type(ocean_public_type), pointer :: Ocean  !< pointer to Ocean
@@ -289,17 +289,19 @@ module full_coupler_mod
   contains
     procedure, public :: coupler_components_obj_init
     procedure, public :: get_component  !< subroutine to retrieve the requested component of an object of this type
-  end type coupler_components_type  
-  
+    procedure, public :: set_component  !< subroutine to set requested component of an object of this type
+  end type coupler_components_type
+
   !> The purpose of objects of coupler_chksum_type is to simplify the list
   !! of arguments required for chksum related subroutines in full_coupler_mod.
-  !! The members of this type point to the model components 
+  !! The members of this type point to the model components
   type coupler_chksum_type
     private
     type(coupler_components_type), pointer :: components
   contains
     procedure, public :: coupler_chksum_obj_init !< associates the pointers above to model components
     procedure, public :: get_components_obj !< subroutine to retrieve the requested component of an object of this type
+    procedure, public :: set_components_obj !< subroutine to set components object
     procedure, public :: get_atmos_ice_land_ocean_chksums !< subroutine to compute chksums for atmos - ocean
     procedure, public :: get_atmos_ice_land_chksums !< subroutine to compute chksums for atmos_ice_land
     procedure, public :: get_slow_ice_chksums       !< subroutine to compute chskums for slow_ice
@@ -1127,7 +1129,7 @@ contains
     !> Initialize coupler_components_obj memebers to point to model components
     call coupler_components_obj%coupler_components_obj_init(Atm, Land, Ice, Ocean, Land_ice_atmos_boundary, &
         Atmos_land_boundary, Atmos_ice_boundary, Land_ice_boundary, Ice_ocean_boundary, Ocean_ice_boundary)
-    
+
     !> Initialize coupler_chksum_obj
     call coupler_chksum_obj%coupler_chksum_obj_init(coupler_components_obj)
 
@@ -1187,7 +1189,7 @@ contains
   subroutine get_component(this, retrieve_component )
 
     implicit none
-    class(coupler_components_type), intent(in) :: this !< the coupler_components_type object 
+    class(coupler_components_type), intent(in) :: this !< the coupler_components_type object
     class(*), intent(out) :: retrieve_component  !< requested component to be retrieve.
                              !! retrieve_component can be of type atmos_data_type, land_data_type, ice_data_type,
                              !! ocean_public_type, land_ice_atmos_boundary_type, atmos_land_boundary_type,
@@ -1195,7 +1197,7 @@ contains
                              !! ocean_ice_boundary_type
 
     select type(retrieve_component)
-    type is(atmos_data_type) ; retrieve_component = this%Atm 
+    type is(atmos_data_type) ; retrieve_component = this%Atm
     type is(land_data_type)  ; retrieve_component = this%Land
     type is(ice_data_type)   ; retrieve_component = this%Ice
     type is(ocean_public_type) ; retrieve_component = this%Ocean
@@ -1209,10 +1211,41 @@ contains
       call fms_mpp_error(FATAL, "failure retrieving component in coupler_components_type object, &
                          cannot recognize the type of requested component")
     end select
-      
+
   end subroutine get_component
-    
-  !> This subroutine associates the pointer in an object of coupler_chksum_type to the component models 
+
+  !> Function set_component sets the requested component in the coupler_components_type object
+  !! Users are required to provide the component to be set as an input argument.  For example,
+  !! coupler_components_obj%get_component(Atm) will set coupler_components_obj%Atm = Atm
+  subroutine set_component(this, set_this_component )
+
+    implicit none
+    class(coupler_components_type), intent(inout) :: this !< the coupler_components_type object
+    class(*), intent(in) :: set_this_component  !< requested component to be be set.
+                            !! set_this_component can be of type atmos_data_type, land_data_type, ice_data_type,
+                            !! ocean_public_type, land_ice_atmos_boundary_type, atmos_land_boundary_type,
+                            !! atmos_ice_boundary_type, land_ice_boundary_type, ice_ocean_boundary_type,
+                            !! ocean_ice_boundary_type
+
+    select type(set_this_component)
+    type is(atmos_data_type)   ; this%Atm  = set_this_component
+    type is(land_data_type)    ; this%Land = set_this_component
+    type is(ice_data_type)     ; this%Ice  = set_this_component
+    type is(ocean_public_type) ; this%Ocean = set_this_component
+    type is(land_ice_atmos_boundary_type) ; this%Land_ice_atmos_boundary = set_this_component
+    type is(atmos_land_boundary_type) ; this%Atmos_land_boundary = set_this_component
+    type is(atmos_ice_boundary_type)  ; this%Atmos_ice_boundary = set_this_component
+    type is(land_ice_boundary_type)   ; this%Land_ice_boundary  = set_this_component
+    type is(ice_ocean_boundary_type)  ; this%Ice_ocean_boundary = set_this_component
+    type is(ocean_ice_boundary_type)  ; this%Ocean_ice_boundary = set_this_component
+    class default
+      call fms_mpp_error(FATAL, "failure setting component in coupler_components_type object, &
+                         cannot recognize the type of requested component")
+    end select
+
+  end subroutine set_component
+
+  !> This subroutine associates the pointer in an object of coupler_chksum_type to the component models
   subroutine coupler_chksum_obj_init(this, components_obj)
 
     implicit none
@@ -1220,20 +1253,32 @@ contains
     type(coupler_components_type), intent(in) :: components_obj
 
     this%components = components_obj
-    
+
   end subroutine coupler_chksum_obj_init
 
   !> This subroutine retrieves coupler_chksum_obj%components_obj
   subroutine get_components_obj(this, components_obj)
 
     implicit none
-    
+
     class(coupler_chksum_type), intent(in)     :: this  !< coupler_chksum_type
     type(coupler_components_type), intent(out) :: components_obj !< coupler_components_type to be returned
 
     components_obj = this%components
-    
+
   end subroutine get_components_obj
+
+  !> This subroutine set coupler_chksum_obj%components_obj
+  subroutine set_components_obj(this, components_obj)
+
+    implicit none
+
+    class(coupler_chksum_type), intent(inout) :: this  !< coupler_chksum_type
+    type(coupler_components_type), intent(in) :: components_obj !< coupler_components_type to be used
+
+    this%components = components_obj
+
+  end subroutine set_components_obj
 
   !> This subroutine finalizes the run
   subroutine coupler_end(Atm, Land, Ice, Ocean, Ocean_state, Land_ice_atmos_boundary, Atmos_ice_boundary,&
@@ -1256,7 +1301,7 @@ contains
     type(FmsNetcdfDomainFile_t), dimension(:), pointer, intent(inout) :: Ice_bc_restart
 
     type(coupler_chksum_type), intent(in) :: coupler_chksum_obj
-    
+
     type(FmsTime_type), intent(in) :: Time, Time_start, Time_end, Time_restart_current
     integer :: num_ice_bc_restart, num_ocn_bc_restart
 
@@ -1428,7 +1473,7 @@ contains
   subroutine get_coupler_chksums(this, id, timestep)
 
     implicit none
-    
+
     class(coupler_chksum_type), intent(in) :: this !< self
     character(len=*), intent(in) :: id        !< id to label CHECKSUMS in stdout
     integer         , intent(in) :: timestep  !< timestep
@@ -1532,7 +1577,7 @@ contains
     class(coupler_chksum_type), intent(in) :: this !< self
     character(len=*), intent(in) :: id       !< ID labelling the set of checksums
     integer         , intent(in) :: timestep !< timestep
-    
+
     if (this%components%Atm%pe) then
       call fms_mpp_set_current_pelist(this%components%Atm%pelist)
       call this%get_atmos_ice_land_chksums(trim(id), timestep)
@@ -1545,7 +1590,7 @@ contains
     call fms_mpp_set_current_pelist()
 
   end subroutine get_atmos_ice_land_ocean_chksums
-  
+
 !> \brief This subroutine calls subroutine that will print out checksums of the elements
 !! of the appropriate type.
 !! For coupled models typically these types are not defined on all processors.
@@ -1920,7 +1965,7 @@ contains
   !> \brief This subroutine calls exchange_fast_to_slow_ice.  Clocks are set before and after the call.
   !! The current pelist is set if the optional argument set_ice_current_pelist is set to true.
   subroutine coupler_exchange_fast_to_slow_ice(Ice, coupler_clocks, set_ice_current_pelist)
-    
+
     implicit none
     type(ice_data_type), intent(inout) :: Ice                 !< Ice
     type(coupler_clock_type), intent(inout) :: coupler_clocks !< coupler_clocks

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -1131,8 +1131,6 @@ contains
     !> Initialize coupler_chksum_obj
     call coupler_chksum_obj%initialize_coupler_chksum_obj(coupler_components_obj)
 
-    do_chksum = .True.
-    
     if ( do_endpoint_chksum ) then
       call coupler_chksum_obj%get_atmos_ice_land_ocean_chksums('coupler_init+', 0)
       if (Ice%slow_ice_PE) then

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -1133,6 +1133,8 @@ contains
     !> Initialize coupler_chksum_obj
     call coupler_chksum_obj%initialize_coupler_chksum_obj(coupler_components_obj)
 
+    do_chksum = .True.
+    
     if ( do_endpoint_chksum ) then
       call coupler_chksum_obj%get_atmos_ice_land_ocean_chksums('coupler_init+', 0)
       if (Ice%slow_ice_PE) then

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -1113,7 +1113,6 @@ contains
                                                     Atmos_land_boundary,Atmos_ice_boundary, Land_ice_boundary, &
                                                     Ice_ocean_boundary, Ocean_ice_boundary)
 
-    do_endpoint_chksum = .False.
     if ( do_endpoint_chksum ) then
       call coupler_atmos_ice_land_ocean_chksum('coupler_init+', 0, Atm, Land, Ice, &
           Land_ice_atmos_boundary, Atmos_ice_boundary, Atmos_land_boundary, Ocean, Ice_ocean_boundary)
@@ -1950,9 +1949,9 @@ contains
     call fms_mpp_clock_begin(coupler_clocks%sfc_boundary_layer)
 
     call sfc_boundary_layer( real(dt_atmos), Time_atmos, Atm, Land, Ice, Land_ice_atmos_boundary )
-    call atmos_ice_land_chksum('sfc+', current_time_step, Atm, Land, Ice, &
-        Land_ice_atmos_boundary, coupler_chksum_obj%Atmos_ice_boundary,                   &
-        coupler_chksum_obj%Atmos_land_boundary)
+    if(do_chksum) call atmos_ice_land_chksum('sfc+', current_time_step, Atm, Land, Ice, &
+                  Land_ice_atmos_boundary, coupler_chksum_obj%Atmos_ice_boundary,       &
+                  coupler_chksum_obj%Atmos_land_boundary)
 
     call fms_mpp_clock_end(coupler_clocks%sfc_boundary_layer)
 

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -1281,7 +1281,6 @@ contains
   end subroutine set_components_obj
 
   !> This subroutine finalizes the run
->>>>>>> origin/tracer_driver_sfc_boundary
   subroutine coupler_end(Atm, Land, Ice, Ocean, Ocean_state, Land_ice_atmos_boundary, Atmos_ice_boundary,&
                          Atmos_land_boundary, Ice_ocean_boundary, Ocean_ice_boundary, Ocn_bc_restart, &
                          Ice_bc_restart, Time, Time_start, Time_end, Time_restart_current, coupler_chksum_obj)
@@ -2044,7 +2043,7 @@ contains
     call fms_mpp_clock_begin(coupler_clocks%sfc_boundary_layer)
 
     call sfc_boundary_layer( real(dt_atmos), Time_atmos, Atm, Land, Ice, Land_ice_atmos_boundary )
-    if(do_chksum) call coupler_chksum_obj%get_atmos_ice_land_chksums('sfc+', current_time_step)
+    if(do_chksum) call coupler_chksum_obj%get_atmos_ice_land_chksums('sfc+', current_timestep)
 
     call fms_mpp_clock_end(coupler_clocks%sfc_boundary_layer)
 
@@ -2064,10 +2063,7 @@ contains
     call update_atmos_model_dynamics(Atm)
     call fms_mpp_clock_end(coupler_clocks%update_atmos_model_dynamics)
 
-    if (do_chksum) call atmos_ice_land_chksum('update_atmos_model_dynamics', current_timestep, &
-        Atm, coupler_chksum_obj%Land, coupler_chksum_obj%Ice, coupler_chksum_obj%Land_ice_atmos_boundary, &
-        coupler_chksum_obj%Atmos_ice_boundary, coupler_chksum_obj%Atmos_land_boundary)
-
+    if (do_chksum) call coupler_chksum_obj%get_atmos_ice_land_chksums('update_atmos_model_dynamics', current_timestep)
     if (do_debug)  call fms_memutils_print_memuse_stats( 'update dyn')
 
   end subroutine coupler_update_atmos_model_dynamics
@@ -2095,8 +2091,8 @@ contains
     if(do_chksum) then
       !> cannot put mpp_chksum for concurrent_radiation as it requires the ability to have two different OpenMP threads
       !! inside of MPI at the same time which is not currently allowed
-      if(.not.do_concurrent_radiation) call atmos_ice_land_chksum('update_atmos_model_radiation(ser)',&
-                                                                  current_timestep, coupler_chksum_obj)
+      if(.not.do_concurrent_radiation) &
+          call coupler_chksum_obj%get_atmos_ice_land_chksums('update_atmos_model_radiation(ser)',current_timestep)
     end if
 
     if (do_debug) then
@@ -2122,7 +2118,7 @@ contains
     call update_atmos_model_down( Land_ice_atmos_boundary, Atm )
     call fms_mpp_clock_end(coupler_clocks%update_atmos_model_down)
 
-    if (do_chksum) call atmos_ice_land_chksum('update_atmos_down+', current_timestep, Atm, coupler_chksum_obj)
+    if (do_chksum) call coupler_chksum_obj%get_atmos_ice_land_chksums('update_atmos_down+', current_timestep)
     if (do_debug)  call fms_memutils_print_memuse_stats( 'update down')
 
   end subroutine coupler_update_atmos_model_down
@@ -2149,7 +2145,7 @@ contains
                               Atmos_land_boundary, Atmos_ice_boundary )
     call fms_mpp_clock_end(coupler_clocks%flux_down_from_atmos)
 
-    if (do_chksum) call atmos_ice_land_chksum('flux_down_from_atmos+', current_timestep, coupler_chksum_obj)
+    if (do_chksum) call coupler_chksum_obj%get_atmos_ice_land_chksums('flux_down_from_atmos+', current_timestep)
 
   end subroutine coupler_flux_down_from_atmos
 


### PR DESCRIPTION
In this PR, the following coupler subroutines have been defined:
1.  coupler_update_land_model_fast
2. coupler_update_ice_model_fast 
3. coupler_update_atmos_model_up
4. coupler_flux_up_to_atmos
5. coupler_update_atmos_model_state

Currently tests are running

The fast coupler loop has been labeled