### PR TITLE
13 - coupler_intermediate restart

### DIFF
--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -557,7 +557,7 @@ program coupler_main
 
           !> checksums are computed if do_chksum=.True.
           call coupler_flux_down_from_atmos(Atm, Land, Ice, Land_ice_atmos_boundary, Atmos_land_boundary, &
-                                            Atmos_ice_boundary, Time_atmos, current_timestep, coupler_clocks)
+               Atmos_ice_boundary, Time_atmos, current_timestep, coupler_clocks, coupler_chksum_obj)
 
           !--------------------------------------------------------------
 
@@ -634,7 +634,9 @@ program coupler_main
 
     !> Ice is still using ATM pelist and need to be included in ATM clock
     !> ATM clock is used for load-balancing the coupled models
-    start_atm_clock2: if(Atm%pe) call fms_mpp_clock_begin(coupler_clocks%atm)
+    start_atm_clock2: if(Atm%pe) then
+      call fms_mpp_clock_begin(coupler_clocks%atm)
+    end if start_atm_clock2
 
     if (do_ice .and. Ice%pe) then
       if (Ice%fast_ice_PE) call coupler_unpack_land_ice_boundary(Ice, Land_ice_boundary, coupler_clocks)

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -675,23 +675,21 @@ program coupler_main
                                        Ice_ocean_boundary, Time_ocean, Time_step_cpld )
       else
         if (do_chksum) call coupler_chksum_obj%get_ocean_chksums('update_ocean_model-', nc)
-
         ! update_ocean_model since fluxes don't change here
         if (do_ocean) call coupler_update_ocean_model(Ocean, Ocean_state, Ice_ocean_boundary, &
                       Time_ocean, Time_step_cpld, current_timestep, coupler_chksum_obj)
-
       end if
 
-        ! Get stocks from "Ice_ocean_boundary" and add them to Ocean stocks.
-        ! This call is just for record keeping of stocks transfer and
-        ! does not modify either Ocean or Ice_ocean_boundary
-        call flux_ocean_from_ice_stocks(Ocean_state, Ocean, Ice_ocean_boundary)
-
-        call fms_diag_send_complete(Time_step_cpld)
-        Time_ocean = Time_ocean +  Time_step_cpld
-        Time = Time_ocean
-
-        call fms_mpp_clock_end(coupler_clocks%ocean)
+      ! Get stocks from "Ice_ocean_boundary" and add them to Ocean stocks.
+      ! This call is just for record keeping of stocks transfer and
+      ! does not modify either Ocean or Ice_ocean_boundary
+      call flux_ocean_from_ice_stocks(Ocean_state, Ocean, Ice_ocean_boundary)
+      
+      call fms_diag_send_complete(Time_step_cpld)
+      Time_ocean = Time_ocean +  Time_step_cpld
+      Time = Time_ocean
+      
+      call fms_mpp_clock_end(coupler_clocks%ocean)
     endif
 
     !> write out intermediate restart file when needead.

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -676,7 +676,7 @@ program coupler_main
       else
         if (do_chksum) call coupler_chksum_obj%get_ocean_chksums('update_ocean_model-', nc)
         ! update_ocean_model since fluxes don't change here
-        if (do_ocean) call coupler_update_ocean_model(Ocean, Ocean_state, Ice_ocean_boundary, &
+        if (do_ocean) call coupler_update_ocean_model(Ocean, Ocean_state, Ice_ocean_boundary,&
                       Time_ocean, Time_step_cpld, current_timestep, coupler_chksum_obj)
       end if
 

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -340,7 +340,7 @@ program coupler_main
   implicit none
 
   !> model defined types.
-  !! Targets to pointers in coupler_chksum_obj
+  !! Targets to pointers in coupler_components_obj
   type (atmos_data_type), target :: Atm
   type  (land_data_type), target :: Land
   type   (ice_data_type), target :: Ice
@@ -372,8 +372,9 @@ program coupler_main
   type(FmsTime_type) :: Time_restart_current
   character(len=32) :: timestamp
 
-  type(coupler_clock_type) :: coupler_clocks
-  type(coupler_chksum_type) :: coupler_chksum_obj
+  type(coupler_clock_type)      :: coupler_clocks
+  type(coupler_components_type) :: coupler_components_obj
+  type(coupler_chksum_type)     :: coupler_chksum_obj
 
   integer :: outunit
   character(len=80) :: text
@@ -429,10 +430,11 @@ program coupler_main
   call coupler_init(Atm, Ocean, Land, Ice, Ocean_state, Atmos_land_boundary, Atmos_ice_boundary, &
     Ocean_ice_boundary, Ice_ocean_boundary, Land_ice_atmos_boundary, Land_ice_boundary,          &
     Ice_ocean_driver_CS, Ice_bc_restart, Ocn_bc_restart, ensemble_pelist, slow_ice_ocean_pelist, &
-    conc_nthreads, coupler_clocks, coupler_chksum_obj, Time_step_cpld, Time_step_atmos, Time_atmos, Time_ocean, &
-    num_cpld_calls, num_atmos_calls, Time, Time_start, Time_end, Time_restart, Time_restart_current)
+    conc_nthreads, coupler_clocks, coupler_components_obj, coupler_chksum_obj, &
+    Time_step_cpld, Time_step_atmos, Time_atmos, Time_ocean, num_cpld_calls,   &
+    num_atmos_calls, Time, Time_start, Time_end, Time_restart, Time_restart_current)
 
-  if (do_chksum) call coupler_chksum('coupler_init+', 0, coupler_chksum_obj)
+  if (do_chksum) call coupler_chksum_obj%coupler_chksum('coupler_init+', 0)
 
   call fms_mpp_set_current_pelist()
   call fms_mpp_clock_end(coupler_clocks%initialization) !end initialization
@@ -448,8 +450,8 @@ program coupler_main
   do nc = 1, num_cpld_calls
 
     if (do_chksum) then
-      call coupler_chksum('top_of_coupled_loop+', nc, coupler_chksum_obj)
-      call coupler_atmos_ice_land_ocean_chksum('MAIN_LOOP-', nc, coupler_chksum_obj)
+      call coupler_chksum_obj%coupler_chksum('top_of_coupled_loop+', nc)
+      call coupler_chksum_obj%coupler_atmos_ice_land_ocean_chksum('MAIN_LOOP-', nc)
     end if
 
     ! Calls to flux_ocean_to_ice and flux_ice_to_ocean are all PE communication
@@ -470,8 +472,8 @@ program coupler_main
     end if
 
     if (do_chksum) then
-      call coupler_chksum('flux_ocn2ice+', nc, coupler_chksum_obj)
-      call coupler_atmos_ice_land_ocean_chksum('flux_ocn2ice+', nc, coupler_chksum_obj)
+      call coupler_chksum_obj%coupler_chksum('flux_ocn2ice+', nc)
+      call coupler_chksum_obj%coupler_atmos_ice_land_ocean_chksum('flux_ocn2ice+', nc)
     end if
 
     ! needs to sit here rather than at the end of the coupler loop.
@@ -497,7 +499,7 @@ program coupler_main
 
       if (.NOT.(do_ice.and.Ice%pe) .OR. (ice_npes.NE.atmos_npes)) call fms_mpp_set_current_pelist(Atm%pelist)
 
-      if(do_chksum) call atmos_ice_land_chksum('set_ice_surface+', nc, coupler_chksum_obj)
+      if(do_chksum) call coupler_chksum_obj%atmos_ice_land_chksum('set_ice_surface+', nc)
 
       call fms_mpp_clock_begin(coupler_clocks%atm)
 
@@ -513,7 +515,7 @@ program coupler_main
         Time_atmos = Time_atmos + Time_step_atmos
         current_timestep = (nc-1)*num_atmos_calls+na
 
-        if (do_chksum) call atmos_ice_land_chksum('top_of_atmos_loop-', current_timestep, coupler_chksum_obj)
+        if (do_chksum) call coupler_chksum_obj%atmos_ice_land_chksum('top_of_atmos_loop-', current_timestep)
 
         if (do_atmos) call coupler_atmos_tracer_driver_gather_data(Atm, coupler_clocks)
 
@@ -551,8 +553,7 @@ program coupler_main
             call update_atmos_model_dynamics(Atm)
             call fms_mpp_clock_end(coupler_clocks%update_atmos_model_dynamics)
           endif
-          if (do_chksum) call atmos_ice_land_chksum('update_atmos_model_dynamics', (nc-1)*num_atmos_calls+na, &
-                                                    coupler_chksum_obj)
+          if (do_chksum) call coupler_chksum_obj%atmos_ice_land_chksum('update_atmos_model_dynamics', current_timestep)
           if (do_debug)  call fms_memutils_print_memuse_stats( 'update dyn')
 
           !      ---- SERIAL atmosphere radiation ----
@@ -561,8 +562,8 @@ program coupler_main
             call update_atmos_model_radiation( Land_ice_atmos_boundary, Atm )
             call fms_mpp_clock_end(coupler_clocks%serial_radiation)
           endif
-          if (do_chksum) call atmos_ice_land_chksum('update_atmos_model_radiation(ser)', (nc-1)*num_atmos_calls+na, &
-                                                    coupler_chksum_obj)
+          if (do_chksum) &
+              call coupler_chksum_obj%atmos_ice_land_chksum('update_atmos_model_radiation(ser)', current_timestep)
           if (do_debug)  call fms_memutils_print_memuse_stats( 'update serial rad')
 
           !      ---- atmosphere down ----
@@ -571,8 +572,7 @@ program coupler_main
             call update_atmos_model_down( Land_ice_atmos_boundary, Atm )
             call fms_mpp_clock_end(coupler_clocks%update_atmos_model_down)
           endif
-          if (do_chksum) call atmos_ice_land_chksum('update_atmos_down+', (nc-1)*num_atmos_calls+na, &
-                                                    coupler_chksum_obj)
+          if (do_chksum) call coupler_chksum_obj%atmos_ice_land_chksum('update_atmos_down+', current_timestep)
           if (do_debug)  call fms_memutils_print_memuse_stats( 'update down')
 
           call fms_mpp_clock_begin(coupler_clocks%flux_down_from_atmos)
@@ -581,8 +581,7 @@ program coupler_main
                                      Atmos_land_boundary, &
                                      Atmos_ice_boundary )
           call fms_mpp_clock_end(coupler_clocks%flux_down_from_atmos)
-          if (do_chksum) call atmos_ice_land_chksum('flux_down_from_atmos+', (nc-1)*num_atmos_calls+na,&
-                                                    coupler_chksum_obj)
+          if (do_chksum) call coupler_chksum_obj%atmos_ice_land_chksum('flux_down_from_atmos+', current_timestep)
 
           !      --------------------------------------------------------------
           !      ---- land model ----
@@ -593,8 +592,7 @@ program coupler_main
           endif
           if (land_npes .NE. atmos_npes) call fms_mpp_set_current_pelist(Atm%pelist)
           call fms_mpp_clock_end(coupler_clocks%update_land_model_fast)
-          if (do_chksum) call atmos_ice_land_chksum('update_land_fast+', (nc-1)*num_atmos_calls+na, &
-                                                    coupler_chksum_obj)
+          if (do_chksum) call coupler_chksum_obj%atmos_ice_land_chksum('update_land_fast+', current_timestep)
           if (do_debug)  call fms_memutils_print_memuse_stats( 'update land')
 
           !      ---- ice model ----
@@ -605,8 +603,7 @@ program coupler_main
           endif
           if (ice_npes .NE. atmos_npes) call fms_mpp_set_current_pelist(Atm%pelist)
           call fms_mpp_clock_end(coupler_clocks%update_ice_model_fast)
-          if (do_chksum) call atmos_ice_land_chksum('update_ice_fast+', (nc-1)*num_atmos_calls+na,&
-                                                    coupler_chksum_obj)
+          if (do_chksum) call coupler_chksum_obj%atmos_ice_land_chksum('update_ice_fast+', current_timestep)
           if (do_debug)  call fms_memutils_print_memuse_stats( 'update ice')
 
           !      --------------------------------------------------------------
@@ -615,14 +612,13 @@ program coupler_main
           call flux_up_to_atmos( Time_atmos, Land, Ice, Land_ice_atmos_boundary, &
                                  Atmos_land_boundary, Atmos_ice_boundary )
           call fms_mpp_clock_end(coupler_clocks%flux_up_to_atmos)
-          if (do_chksum) call atmos_ice_land_chksum('flux_up2atmos+', (nc-1)*num_atmos_calls+na,coupler_chksum_obj)
+          if (do_chksum) call coupler_chksum_obj%atmos_ice_land_chksum('flux_up2atmos+', current_timestep)
 
           call fms_mpp_clock_begin(coupler_clocks%update_atmos_model_up)
           if (do_atmos) &
             call update_atmos_model_up( Land_ice_atmos_boundary, Atm)
           call fms_mpp_clock_end(coupler_clocks%update_atmos_model_up)
-          if (do_chksum) call atmos_ice_land_chksum('update_atmos_up+', (nc-1)*num_atmos_calls+na, &
-                                                    coupler_chksum_obj)
+          if (do_chksum) call coupler_chksum_obj%atmos_ice_land_chksum('update_atmos_up+', current_timestep)
           if (do_debug)  call fms_memutils_print_memuse_stats( 'update up')
 
           call flux_atmos_to_ocean(Time_atmos, Atm, Atmos_ice_boundary, Ice)
@@ -667,8 +663,7 @@ program coupler_main
 
         call fms_mpp_clock_begin(coupler_clocks%update_atmos_model_state)
         call update_atmos_model_state( Atm )
-        if (do_chksum) call atmos_ice_land_chksum('update_atmos_model_state+', (nc-1)*num_atmos_calls+na,&
-                                                  coupler_chksum_obj)
+        if (do_chksum) call coupler_chksum_obj%atmos_ice_land_chksum('update_atmos_model_state+', current_timestep)
         if (do_debug)  call fms_memutils_print_memuse_stats( 'update state')
         call fms_mpp_clock_end(coupler_clocks%update_atmos_model_state)
 
@@ -685,15 +680,15 @@ program coupler_main
       if (land_npes .NE. atmos_npes) call fms_mpp_set_current_pelist(Atm%pelist)
       !-----------------------------------------------------------------------
       call fms_mpp_clock_end(coupler_clocks%update_land_model_slow)
-      if (do_chksum) call atmos_ice_land_chksum('update_land_slow+', nc, coupler_chksum_obj)
-
+      if (do_chksum) call coupler_chksum_obj%atmos_ice_land_chksum('update_land_slow+', nc)
+      
       !
       !     need flux call to put runoff and p_surf on ice grid
       !
       call fms_mpp_clock_begin(coupler_clocks%flux_land_to_ice)
       call flux_land_to_ice( Time, Land, Ice, Land_ice_boundary )
       call fms_mpp_clock_end(coupler_clocks%flux_land_to_ice)
-      if (do_chksum) call atmos_ice_land_chksum('fluxlnd2ice+', nc, coupler_chksum_obj)
+      if (do_chksum) call coupler_chksum_obj%atmos_ice_land_chksum('fluxlnd2ice+', nc)
 
       Atmos_ice_boundary%p = 0.0 ! call flux_atmos_to_ice_slow ?
       Time = Time_atmos
@@ -734,7 +729,7 @@ program coupler_main
         call fms_mpp_clock_end(coupler_clocks%update_ice_model_slow_slow)
       endif
 
-      if (do_chksum) call slow_ice_chksum('update_ice_slow+', nc, coupler_chksum_obj)
+      if (do_chksum) call coupler_chksum_obj%slow_ice_chksum('update_ice_slow+', nc)
      endif  ! End of Ice%pe block
 
      if(Atm%pe) then
@@ -771,7 +766,7 @@ program coupler_main
                                  Time_ocean, Time_step_cpld )
       endif
 
-      if (do_chksum) call ocean_chksum('update_ocean_model+', nc, coupler_chksum_obj)
+      if (do_chksum) call coupler_chksum_obj%ocean_chksum('update_ocean_model+', nc)
       ! Get stocks from "Ice_ocean_boundary" and add them to Ocean stocks.
       ! This call is just for record keeping of stocks transfer and
       ! does not modify either Ocean or Ice_ocean_boundary
@@ -828,7 +823,7 @@ program coupler_main
   call fms_mpp_clock_end(coupler_clocks%main)
   call fms_mpp_clock_begin(coupler_clocks%termination)
 
-  if (do_chksum) call coupler_chksum('coupler_end-', nc, coupler_chksum_obj)
+  if (do_chksum) call coupler_chksum_obj%coupler_chksum('coupler_end-', nc)
   call coupler_end(Atm, Land, Ice, Ocean, Ocean_state, Land_ice_atmos_boundary, Atmos_ice_boundary,&
       Atmos_land_boundary, Ice_ocean_boundary, Ocean_ice_boundary, Ocn_bc_restart, Ice_bc_restart, &
       Time, Time_start, Time_end, Time_restart_current, coupler_chksum_obj)

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -814,8 +814,6 @@ program coupler_main
     imb_sec(:)=0.
     call flush(outunit)
 
-    stop
-    
   enddo
 102 FORMAT(A17,i5,A4,i5,A24,f10.4,A2,f10.4,A3,f10.4,A2,f10.4,A1)
 

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -570,12 +570,12 @@ program coupler_main
           !--------------------------------------------------------------
 
           !> land model 
-          if (do_land .AND. land%pe) call update_land_model_fast(Land, Atmos_land_boundary, current_timestep,&
-                                                                 coupler_chksum_obj, coupler_clocks)
+          if (do_land .AND. land%pe) call coupler_update_land_model_fast(Land, Atmos_land_boundary, Atm%pelist, &
+                                     current_timestep, coupler_chksum_obj, coupler_clocks)
 
           !> ice model
-          if (do_ice .AND. Ice%fast_ice_pe) call update_ice_model_fast(Ice, Atmos_ice_boundary, current_timestep,&
-                                                                       coupler_chksum_obj, coupler_clocks)
+          if (do_ice .AND. Ice%fast_ice_pe) call coupler_update_ice_model_fast(Ice, Atmos_ice_boundary, Atm%pelist, &
+                                            current_timestep, coupler_chksum_obj, coupler_clocks)
 
           !--------------------------------------------------------------
 

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -513,7 +513,7 @@ program coupler_main
       !> atmos/fast-land/fast-ice integration loop 
 
       call fms_mpp_clock_begin(coupler_clocks%atmos_loop)
-      do na = 1, num_atmos_calls
+      fast_integration_loop : do na = 1, num_atmos_calls
 
         Time_atmos = Time_atmos + Time_step_atmos
         current_timestep = (nc-1)*num_atmos_calls+na
@@ -616,14 +616,9 @@ program coupler_main
 !$      if (do_concurrent_radiation) imb_sec(2) = imb_sec(2) + omp_get_wtime()
 !$      call omp_set_num_threads(atmos_nthreads+(conc_nthreads-1)*radiation_nthreads)
 
-        call fms_mpp_clock_begin(coupler_clocks%update_atmos_model_state)
-        call update_atmos_model_state( Atm )
-        if (do_chksum) call atmos_ice_land_chksum('update_atmos_model_state+', (nc-1)*num_atmos_calls+na, Atm, Land, &
-                  Ice,Land_ice_atmos_boundary, Atmos_ice_boundary, Atmos_land_boundary)
-        if (do_debug)  call fms_memutils_print_memuse_stats( 'update state')
-        call fms_mpp_clock_end(coupler_clocks%update_atmos_model_state)
-
-      enddo ! end of na (fast loop)
+        call coupler_update_atmos_model_state(Atm, current_timestep, coupler_chksum_obj, coupler_clocks )
+        
+      enddo fast_integration_loop ! end of na (fast loop)
 
       call fms_mpp_clock_end(coupler_clocks%atmos_loop)
 

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -419,7 +419,7 @@ program coupler_main
 
   call fms_mpp_init()
 
-  !these clocks are on the global pelist
+  !>these clocks are on the global pelist
   coupler_clocks%initialization = fms_mpp_clock_id( 'Initialization' )
   call fms_mpp_clock_begin(coupler_clocks%initialization)
 
@@ -437,11 +437,12 @@ program coupler_main
   if (do_chksum) call coupler_chksum_obj%get_coupler_chksums('coupler_init+', 0)
 
   call fms_mpp_set_current_pelist()
-  call fms_mpp_clock_end(coupler_clocks%initialization) !end initialization
-  call fms_mpp_clock_begin(coupler_clocks%main)         !begin main loop
+  call fms_mpp_clock_end(coupler_clocks%initialization) !>end initialization
 
-!-----------------------------------------------------------------------
-!> ocean/slow-ice integration loop
+  !> begin main loop
+  call fms_mpp_clock_begin(coupler_clocks%main)
+
+  !> ocean/slow-ice integration loop
 
   if (check_stocks >= 0) call coupler_flux_init_finish_stocks(Time, Atm, Land, Ice, Ocean_state, &
                                                               coupler_clocks, init_stocks=.True.)
@@ -453,17 +454,15 @@ program coupler_main
       call coupler_chksum_obj%get_atmos_ice_land_ocean_chksums('MAIN_LOOP-', nc)
     end if
 
-    ! Calls to flux_ocean_to_ice and flux_ice_to_ocean are all PE communication
-    ! points when running concurrently. The calls are placed next to each other in
-    ! concurrent mode to avoid multiple synchronizations within the main loop.
-    ! With concurrent_ice, these only occur on the ocean PEs.
+    !> Calls to flux_ocean_to_ice and flux_ice_to_ocean are all PE communication
+    !! points when running concurrently. The calls are placed next to each other in
+    !! concurrent mode to avoid multiple synchronizations within the main loop.
+    !! With concurrent_ice, these only occur on the ocean PEs.
     if (Ice%slow_ice_PE .or. Ocean%is_ocean_pe) then
-
-      !Redistribute quantities from Ocean to Ocean_ice_boundary
+      !> Redistribute quantities from Ocean to Ocean_ice_boundary
       call coupler_flux_ocean_to_ice(Ocean, Ice, Ocean_ice_boundary, coupler_clocks, slow_ice_ocean_pelist)
       Time_flux_ocean_to_ice = Time
-
-      ! Update Ice_ocean_boundary; the first iteration is supplied by restarts
+      !> Update Ice_ocean_boundary; the first iteration is supplied by restarts
       if(use_lag_fluxes) then
         call coupler_flux_ice_to_ocean(Ice, Ocean, Ice_ocean_boundary, coupler_clocks)
         Time_flux_ice_to_ocean = Time
@@ -481,25 +480,23 @@ program coupler_main
     if (do_ice .and. Ice%pe) then
       if (Ice%slow_ice_pe) call coupler_unpack_ocean_ice_boundary(nc, Time_flux_ocean_to_ice, Ice, Ocean_ice_boundary,&
                                                                   coupler_clocks, coupler_chksum_obj)
-
-      ! This could be a point where the model is serialized if the fast and
-      ! slow ice are on different PEs.  call fms_mpp_set_current_pelist(Ice%pelist)
-      ! is called if(.not.Ice%shared_slow_fast_PEs)
+      !> This could be a point where the model is serialized if the fast and
+      !! slow ice are on different PEs.  call fms_mpp_set_current_pelist(Ice%pelist)
+      !! is called if(.not.Ice%shared_slow_fast_PEs)
       call coupler_exchange_slow_to_fast_ice(Ice, coupler_clocks)
-
-      ! This call occurs all ice PEs.
+      !> This call occurs all ice PEs.
       if (concurrent_ice) call coupler_exchange_fast_to_slow_ice(Ice, coupler_clocks)
-
-      ! call fms_mpp_set_current_pelist(Ice%pelist) is called if(.not.Ice%shared_slow_fast_PEs)
+      !> call fms_mpp_set_current_pelist(Ice%pelist) is called if(.not.Ice%shared_slow_fast_PEs)
       if (Ice%fast_ice_pe) call coupler_set_ice_surface_fields(Ice, coupler_clocks)
     endif
 
-    if (Atm%pe) then
+    atm_pe_block : if (Atm%pe) then
 
       if (.NOT.(do_ice.and.Ice%pe) .OR. (ice_npes.NE.atmos_npes)) call fms_mpp_set_current_pelist(Atm%pelist)
 
       if(do_chksum) call coupler_chksum_obj%get_atmos_ice_land_chksums('set_ice_surface+', nc)
 
+      !> begin atm_clock_1
       call fms_mpp_clock_begin(coupler_clocks%atm)
 
       call coupler_generate_sfc_xgrid(Land, Ice, coupler_clocks)
@@ -615,72 +612,46 @@ program coupler_main
       enddo fast_integration_loop ! end of na (fast loop)
 
       call fms_mpp_clock_end(coupler_clocks%atmos_loop)
+      !> end of atmospheric time step loop
 
-      call fms_mpp_clock_begin(coupler_clocks%update_land_model_slow)
-      !   ------ end of atmospheric time step loop -----
-      if (do_land .AND. Land%pe) then
-        if (land_npes .NE. atmos_npes) call fms_mpp_set_current_pelist(Land%pelist)
-        call update_land_model_slow(Atmos_land_boundary,Land)
-      endif
-      if (land_npes .NE. atmos_npes) call fms_mpp_set_current_pelist(Atm%pelist)
-      !-----------------------------------------------------------------------
-      call fms_mpp_clock_end(coupler_clocks%update_land_model_slow)
-      if (do_chksum) call coupler_chksum_obj%get_atmos_ice_land_chksums('update_land_slow+', nc)
+      !> update_land_mode_slow occurs from LAND%PE
+      if (do_land) call coupler_update_land_model_slow(Land, Atmos_land_boundary, &
+                   Atm%pelist, current_timestep, coupler_chksum_obj, coupler_clocks)
 
-      !
-      !     need flux call to put runoff and p_surf on ice grid
-      !
-      call fms_mpp_clock_begin(coupler_clocks%flux_land_to_ice)
-      call flux_land_to_ice( Time, Land, Ice, Land_ice_boundary )
-      call fms_mpp_clock_end(coupler_clocks%flux_land_to_ice)
-      if (do_chksum) call coupler_chksum_obj%get_atmos_ice_land_chksums('fluxlnd2ice+', nc)
+      !> need flux call to put runoff and p_surf on ice grid
+      call coupler_flux_land_to_ice(Land, Ice, Land_ice_boundary, Time, current_timestep, &
+                                    coupler_chksum_obj, coupler_clocks)
 
-      Atmos_ice_boundary%p = 0.0 ! call flux_atmos_to_ice_slow ?
+      !> call flux_atmos_to_ice_slow ?
+      Atmos_ice_boundary%p = 0.0
+
       Time = Time_atmos
+
+      !> end atm_clock_1
       call fms_mpp_clock_end(coupler_clocks%atm)
-    endif                     !Atm%pe block
 
-    if(Atm%pe) then
-     call fms_mpp_clock_begin(coupler_clocks%atm) !Ice is still using ATM pelist and need to be included in ATM clock
-                                                       !ATM clock is used for load-balancing the coupled models
-    endif
+    endif atm_pe_block
+
+    !> Ice is still using ATM pelist and need to be included in ATM clock
+    !> ATM clock is used for load-balancing the coupled models
+    start_atm_clock2: if(Atm%pe) call fms_mpp_clock_begin(coupler_clocks%atm)
+
     if (do_ice .and. Ice%pe) then
-
-      if (Ice%fast_ice_PE) then
-           if (ice_npes .NE. atmos_npes) call fms_mpp_set_current_pelist(Ice%fast_pelist)
-        call fms_mpp_clock_begin(coupler_clocks%update_ice_model_slow_fast)
-       ! These two calls occur on whichever PEs handle the fast ice processess.
-        call ice_model_fast_cleanup(Ice)
-
-        call unpack_land_ice_boundary(Ice, Land_ice_boundary)
-        call fms_mpp_clock_end(coupler_clocks%update_ice_model_slow_fast)
-      endif
-
-      ! This could be a point where the model is serialized; This calls on all ice PEs
+      if (Ice%fast_ice_PE) call coupler_unpack_land_ice_boundary(Ice, Land_ice_boundary, coupler_clocks)
+      !> This could be a point where the model is serialized; This calls on all ice PEs
       if (.not.concurrent_ice) call coupler_exchange_fast_to_slow_ice(Ice, coupler_clocks, &
-                                                                      set_ice_current_pelist=.True.)
-
-      !   ------ slow-ice model ------
-
-      ! This call occurs on whichever PEs handle the slow ice processess.
-      if (Ice%slow_ice_PE .and. .not.combined_ice_and_ocean) then
-        if (slow_ice_with_ocean) call fms_mpp_set_current_pelist(Ice%slow_pelist)
-        call fms_mpp_clock_begin(coupler_clocks%update_ice_model_slow_slow)
-        call update_ice_model_slow(Ice)
-
-        call fms_mpp_clock_begin(coupler_clocks%flux_ice_to_ocean_stocks)
-        call flux_ice_to_ocean_stocks(Ice)
-        call fms_mpp_clock_end(coupler_clocks%flux_ice_to_ocean_stocks)
-        call fms_mpp_clock_end(coupler_clocks%update_ice_model_slow_slow)
-      endif
-
+                               set_ice_current_pelist=.True.)
+      !> slow-ice model
+      !! This call occurs on whichever PEs handle the slow ice processess.
+      if (Ice%slow_ice_PE .and. .not.combined_ice_and_ocean) &
+          call coupler_update_ice_model_slow_and_stocks(Ice, coupler_clocks)
       if (do_chksum) call coupler_chksum_obj%get_slow_ice_chksums('update_ice_slow+', nc)
-     endif  ! End of Ice%pe block
+    endif  ! End of Ice%pe block
 
-     if(Atm%pe) then
-        call fms_mpp_set_current_pelist(Atm%pelist)
-        call fms_mpp_clock_end(coupler_clocks%atm)
-     endif
+    end_atm_clock2: if(Atm%pe) then
+      call fms_mpp_set_current_pelist(Atm%pelist)
+      call fms_mpp_clock_end(coupler_clocks%atm)
+    endif end_atm_clock2
 
     ! Update Ice_ocean_boundary using the newly calculated fluxes.
     if ((concurrent_ice .or. .not.use_lag_fluxes) .and. .not.combined_ice_and_ocean) then

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -339,21 +339,22 @@ program coupler_main
   use iso_fortran_env
   implicit none
 
-  !> model defined types
-  type (atmos_data_type) :: Atm
-  type  (land_data_type) :: Land
-  type   (ice_data_type) :: Ice
+  !> model defined types.
+  !! Targets to pointers in coupler_chksum_obj
+  type (atmos_data_type), target :: Atm
+  type  (land_data_type), target :: Land
+  type   (ice_data_type), target :: Ice
   ! allow members of ocean type to be aliased (ap)
-  type (ocean_public_type), target  :: Ocean
+  type (ocean_public_type), target  :: Ocean 
   type (ocean_state_type),  pointer :: Ocean_state => NULL()
 
-  type(atmos_land_boundary_type) :: Atmos_land_boundary
-  type(atmos_ice_boundary_type)  :: Atmos_ice_boundary
-  type(land_ice_atmos_boundary_type)  :: Land_ice_atmos_boundary
-  type(land_ice_boundary_type)  :: Land_ice_boundary
-  type(ice_ocean_boundary_type) :: Ice_ocean_boundary
-  type(ocean_ice_boundary_type) :: Ocean_ice_boundary
-  type(ice_ocean_driver_type), pointer :: ice_ocean_driver_CS => NULL()
+  type(atmos_land_boundary_type), target :: Atmos_land_boundary
+  type(atmos_ice_boundary_type), target  :: Atmos_ice_boundary
+  type(land_ice_atmos_boundary_type), target  :: Land_ice_atmos_boundary
+  type(land_ice_boundary_type), target  :: Land_ice_boundary
+  type(ice_ocean_boundary_type), target :: Ice_ocean_boundary
+  type(ocean_ice_boundary_type), target :: Ocean_ice_boundary
+  type(ice_ocean_driver_type), pointer  :: ice_ocean_driver_CS => NULL()
 
   type(FmsTime_type) :: Time
   type(FmsTime_type) :: Time_step_atmos, Time_step_cpld
@@ -371,6 +372,7 @@ program coupler_main
   character(len=32) :: timestamp
 
   type(coupler_clock_type) :: coupler_clocks
+  class(coupler_chksum_type) :: coupler_chksum_obj
 
   integer :: outunit
   character(len=80) :: text
@@ -426,7 +428,7 @@ program coupler_main
   call coupler_init(Atm, Ocean, Land, Ice, Ocean_state, Atmos_land_boundary, Atmos_ice_boundary, &
     Ocean_ice_boundary, Ice_ocean_boundary, Land_ice_atmos_boundary, Land_ice_boundary,          &
     Ice_ocean_driver_CS, Ice_bc_restart, Ocn_bc_restart, ensemble_pelist, slow_ice_ocean_pelist, &
-    conc_nthreads, coupler_clocks, Time_step_cpld, Time_step_atmos, Time_atmos, Time_ocean,      &
+    conc_nthreads, coupler_clocks, coupler_chksum_obj, Time_step_cpld, Time_step_atmos, Time_atmos, Time_ocean, &
     num_cpld_calls, num_atmos_calls, Time, Time_start, Time_end, Time_restart, Time_restart_current)
 
   if (do_chksum) call coupler_chksum('coupler_init+', 0, Atm, Land, Ice)

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -682,7 +682,7 @@ program coupler_main
       !-----------------------------------------------------------------------
       call fms_mpp_clock_end(coupler_clocks%update_land_model_slow)
       if (do_chksum) call coupler_chksum_obj%get_atmos_ice_land_chksums('update_land_slow+', nc)
-      
+
       !
       !     need flux call to put runoff and p_surf on ice grid
       !

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -443,7 +443,7 @@ program coupler_main
                                                               coupler_clocks, init_stocks=.True.)
 
   !> ocean/slow-ice integration loop
-  slow_integration_loop : do nc = 1, num_cpld_calls
+  coupled_timestep_loop : do nc = 1, num_cpld_calls
 
     if (do_chksum) then
       call coupler_chksum_obj%get_coupler_chksums('top_of_coupled_loop+', nc)
@@ -702,7 +702,7 @@ program coupler_main
     omp_sec(:)=0.
     imb_sec(:)=0.
 
-  enddo slow_integration_loop
+  enddo coupled_timestep_loop
 
   !-----------------------------------------------------------------------
   if( check_stocks >=0 ) call coupler_flux_init_finish_stocks(Time, Atm, Land, Ice, Ocean_state, &

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -369,15 +369,11 @@ program coupler_main
   type(FmsNetcdfDomainFile_t), dimension(:), pointer :: Ocn_bc_restart => NULL()
 
   type(FmsTime_type) :: Time_restart, Time_start, Time_end
-  type(FmsTime_type) :: Time_restart_current
-  character(len=32) :: timestamp
 
   type(coupler_clock_type)      :: coupler_clocks
   type(coupler_components_type), target :: coupler_components_obj
   type(coupler_chksum_type)     :: coupler_chksum_obj
 
-  integer :: outunit
-  character(len=80) :: text
   integer, allocatable :: ensemble_pelist(:, :)
   integer, allocatable :: slow_ice_ocean_pelist(:)
   integer :: conc_nthreads = 1
@@ -432,7 +428,7 @@ program coupler_main
     Ice_ocean_driver_CS, Ice_bc_restart, Ocn_bc_restart, ensemble_pelist, slow_ice_ocean_pelist, &
     conc_nthreads, coupler_clocks, coupler_components_obj, coupler_chksum_obj, &
     Time_step_cpld, Time_step_atmos, Time_atmos, Time_ocean, num_cpld_calls,   &
-    num_atmos_calls, Time, Time_start, Time_end, Time_restart, Time_restart_current)
+    num_atmos_calls, Time, Time_start, Time_end, Time_restart)
 
   if (do_chksum) call coupler_chksum_obj%get_coupler_chksums('coupler_init+', 0)
 
@@ -447,7 +443,7 @@ program coupler_main
   if (check_stocks >= 0) call coupler_flux_init_finish_stocks(Time, Atm, Land, Ice, Ocean_state, &
                                                               coupler_clocks, init_stocks=.True.)
 
-  do nc = 1, num_cpld_calls
+  slow_integration_loop : do nc = 1, num_cpld_calls
 
     if (do_chksum) then
       call coupler_chksum_obj%get_coupler_chksums('top_of_coupled_loop+', nc)
@@ -681,6 +677,8 @@ program coupler_main
         ! update_ocean_model since fluxes don't change here        
         if (do_ocean) call coupler_update_ocean_model(Ice_ocean_boundary, Ocean_state,  Ocean, &
                       Time_ocean, Time_step_cpld, current_timestep, coupler_chksum_type)
+
+      end if
         
         ! Get stocks from "Ice_ocean_boundary" and add them to Ocean stocks.
         ! This call is just for record keeping of stocks transfer and
@@ -694,42 +692,17 @@ program coupler_main
         call fms_mpp_clock_end(coupler_clocks%ocean)
     endif
 
-    !--- write out intermediate restart file when needed.
-    if (Time >= Time_restart) then
-      Time_restart_current = Time
-      Time_restart = fms_time_manager_increment_date(Time, restart_interval(1), restart_interval(2), &
-           restart_interval(3), restart_interval(4), restart_interval(5), restart_interval(6) )
-      timestamp = fms_time_manager_date_to_string(time_restart_current)
-      outunit= fms_mpp_stdout()
-      write(outunit,*) '=> NOTE from program coupler: intermediate restart file is written and ', &
-           trim(timestamp),' is appended as prefix to each restart file name'
-      if (Atm%pe) then
-        call atmos_model_restart(Atm, timestamp)
-        call land_model_restart(timestamp)
-        call ice_model_restart(Ice, timestamp)
-      endif
-      if (Ocean%is_ocean_pe) then
-        call ocean_model_restart(Ocean_state, timestamp)
-      endif
-      call coupler_restart(Atm, Ice, Ocean, Ocn_bc_restart, Ice_bc_restart, &
-                           Time, Time_restart_current, Time_start, Time_end, timestamp)
-    endif
+    !> write out intermediate restart file when needead.
+    if (Time >= Time_restart) &
+        call coupler_intermediate_restart(Atm, Ice, Ocean, Ocean_bc_restart, Ice_bc_restart, Time, Time_restart)
 
     !--------------
-    if (do_chksum) call coupler_chksum_obj%get_coupler_chksums('MAIN_LOOP+', nc)
-    write( text,'(a,i6)' )'Main loop at coupling timestep=', nc
-    call fms_memutils_print_memuse_stats(text)
-    outunit= fms_mpp_stdout()
-    if (fms_mpp_pe() == fms_mpp_root_pe() .and. Atm%pe .and. do_concurrent_radiation) then
-      write(outunit,102) 'At coupling step ', nc,' of ',num_cpld_calls, &
-           ' Atm & Rad (imbalance): ',omp_sec(1),' (',imb_sec(1),')  ',omp_sec(2),' (',imb_sec(2),')'
-    endif
+    call coupler_summarize_timestep(current_timestep, coupler_chksum_obj, Atm%pe, omp_sec, imb_sec)
     omp_sec(:)=0.
     imb_sec(:)=0.
-    call flush(outunit)
 
-  enddo
-102 FORMAT(A17,i5,A4,i5,A24,f10.4,A2,f10.4,A3,f10.4,A2,f10.4,A1)
+  enddo slow_integration_loop
+  
 
   if( check_stocks >=0 ) call coupler_flux_init_finish_stocks(Time, Atm, Land, Ice, Ocean_state, &
                                                               coupler_clocks, finish_stocks=.True.)
@@ -741,11 +714,11 @@ program coupler_main
   if (do_chksum) call coupler_chksum_obj%get_coupler_chksums('coupler_end-', nc)
   call coupler_end(Atm, Land, Ice, Ocean, Ocean_state, Land_ice_atmos_boundary, Atmos_ice_boundary,&
       Atmos_land_boundary, Ice_ocean_boundary, Ocean_ice_boundary, Ocn_bc_restart, Ice_bc_restart, &
-      Time, Time_start, Time_end, Time_restart_current, coupler_chksum_obj)
+      Time, Time_start, Time_end, coupler_chksum_obj)
 
   call fms_mpp_clock_end(coupler_clocks%termination)
 
-  call fms_memutils_print_memuse_stats( 'Memory HiWaterMark', always=.TRUE. )
+  call fms_memutils_print_memuse_stats( 'Memory HiWaterMark', always=.True. )
   call fms_end
 
 !-----------------------------------------------------------------------

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -345,7 +345,7 @@ program coupler_main
   type  (land_data_type), target :: Land
   type   (ice_data_type), target :: Ice
   ! allow members of ocean type to be aliased (ap)
-  type (ocean_public_type), target  :: Ocean 
+  type (ocean_public_type), target  :: Ocean
   type (ocean_state_type),  pointer :: Ocean_state => NULL()
 
   type(atmos_land_boundary_type), target :: Atmos_land_boundary
@@ -439,7 +439,7 @@ program coupler_main
   call fms_mpp_clock_begin(coupler_clocks%main)         !begin main loop
 
 !-----------------------------------------------------------------------
-!> ocean/slow-ice integration loop 
+!> ocean/slow-ice integration loop
 
   if (check_stocks >= 0) call coupler_flux_init_finish_stocks(Time, Atm, Land, Ice, Ocean_state, &
                                                               coupler_clocks, init_stocks=.True.)
@@ -510,7 +510,7 @@ program coupler_main
 
       !-----------------------------------------------------------------------
 
-      !> atmos/fast-land/fast-ice integration loop 
+      !> atmos/fast-land/fast-ice integration loop
 
       call fms_mpp_clock_begin(coupler_clocks%atmos_loop)
       fast_integration_loop : do na = 1, num_atmos_calls
@@ -526,7 +526,7 @@ program coupler_main
         if (do_flux) call coupler_sfc_boundary_layer(Atm, Land, Ice, Land_ice_atmos_boundary, &
                                                      Time_atmos, current_timestep, coupler_chksum_obj, coupler_clocks)
 
-        
+
 !$OMP   PARALLEL  &
 !$OMP&    NUM_THREADS(conc_nthreads)  &
 !$OMP&    DEFAULT(NONE)  &
@@ -569,7 +569,7 @@ program coupler_main
 
           !--------------------------------------------------------------
 
-          !> land model 
+          !> land model
           if (do_land .AND. land%pe) call coupler_update_land_model_fast(Land, Atmos_land_boundary, Atm%pelist, &
                                      current_timestep, coupler_chksum_obj, coupler_clocks)
 
@@ -579,10 +579,10 @@ program coupler_main
 
           !--------------------------------------------------------------
 
-          !> atmosphere up 
+          !> atmosphere up
           call coupler_flux_up_to_atmos(Land, Ice, Land_ice_atmos_boundary, Atmos_land_boundary, Atmos_ice_boundary,&
                                         Time_atmos, current_timestep, coupler_chksum_obj, coupler_clocks)
-          
+
           if (do_atmos) call coupler_update_atmos_model_up(Atm, Land_ice_atmos_boundary, current_timestep, &
                                                            coupler_chksum_obj, coupler_clocks)
 
@@ -617,7 +617,7 @@ program coupler_main
 !$      call omp_set_num_threads(atmos_nthreads+(conc_nthreads-1)*radiation_nthreads)
 
         call coupler_update_atmos_model_state(Atm, current_timestep, coupler_chksum_obj, coupler_clocks )
-        
+
       enddo fast_integration_loop ! end of na (fast loop)
 
       call fms_mpp_clock_end(coupler_clocks%atmos_loop)

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -506,10 +506,6 @@ program coupler_main
       call send_ice_mask_sic(Time)
 
       !-----------------------------------------------------------------------
-<<<<<<< HEAD
-
-=======
->>>>>>> origin/atmos_model-flux_down
       !> atmos/fast-land/fast-ice integration loop
 
       call fms_mpp_clock_begin(coupler_clocks%atmos_loop)
@@ -566,7 +562,6 @@ program coupler_main
           call coupler_flux_down_from_atmos(Atm, Land, Ice, Land_ice_atmos_boundary, Atmos_land_boundary, &
                                             Atmos_ice_boundary, Time_atmos, current_timestep, coupler_clocks)
 
-<<<<<<< HEAD
           !--------------------------------------------------------------
 
           !> land model
@@ -578,46 +573,6 @@ program coupler_main
                                             current_timestep, coupler_chksum_obj, coupler_clocks)
 
           !--------------------------------------------------------------
-=======
-          !      --------------------------------------------------------------
-          !      ---- land model ----
-          call fms_mpp_clock_begin(coupler_clocks%update_land_model_fast)
-          if (do_land .AND. land%pe) then
-            if (land_npes .NE. atmos_npes) call fms_mpp_set_current_pelist(Land%pelist)
-            call update_land_model_fast( Atmos_land_boundary, Land )
-          endif
-          if (land_npes .NE. atmos_npes) call fms_mpp_set_current_pelist(Atm%pelist)
-          call fms_mpp_clock_end(coupler_clocks%update_land_model_fast)
-          if (do_chksum) call coupler_chksum_obj%get_atmos_ice_land_chksums('update_land_fast+', current_timestep)
-          if (do_debug)  call fms_memutils_print_memuse_stats( 'update land')
-
-          !      ---- ice model ----
-          call fms_mpp_clock_begin(coupler_clocks%update_ice_model_fast)
-          if (do_ice .AND. Ice%fast_ice_pe) then
-            if (ice_npes .NE. atmos_npes)call fms_mpp_set_current_pelist(Ice%fast_pelist)
-            call update_ice_model_fast( Atmos_ice_boundary, Ice )
-          endif
-          if (ice_npes .NE. atmos_npes) call fms_mpp_set_current_pelist(Atm%pelist)
-          call fms_mpp_clock_end(coupler_clocks%update_ice_model_fast)
-          if (do_chksum) call coupler_chksum_obj%get_atmos_ice_land_chksums('update_ice_fast+', current_timestep)
-          if (do_debug)  call fms_memutils_print_memuse_stats( 'update ice')
-
-          !      --------------------------------------------------------------
-          !      ---- atmosphere up ----
-          call fms_mpp_clock_begin(coupler_clocks%flux_up_to_atmos)
-          call flux_up_to_atmos( Time_atmos, Land, Ice, Land_ice_atmos_boundary, &
-                                 Atmos_land_boundary, Atmos_ice_boundary )
-          call fms_mpp_clock_end(coupler_clocks%flux_up_to_atmos)
-          if (do_chksum) call coupler_chksum_obj%get_atmos_ice_land_chksums('flux_up2atmos+', current_timestep)
-
-          call fms_mpp_clock_begin(coupler_clocks%update_atmos_model_up)
-          if (do_atmos) &
-            call update_atmos_model_up( Land_ice_atmos_boundary, Atm)
-          call fms_mpp_clock_end(coupler_clocks%update_atmos_model_up)
-          if (do_chksum) call coupler_chksum_obj%get_atmos_ice_land_chksums('update_atmos_up+', current_timestep)
-          if (do_debug)  call fms_memutils_print_memuse_stats( 'update up')
->>>>>>> origin/atmos_model-flux_down
-
           !> atmosphere up
           call coupler_flux_up_to_atmos(Land, Ice, Land_ice_atmos_boundary, Atmos_land_boundary, Atmos_ice_boundary,&
                                         Time_atmos, current_timestep, coupler_chksum_obj, coupler_clocks)
@@ -655,15 +610,7 @@ program coupler_main
 !$      if (do_concurrent_radiation) imb_sec(2) = imb_sec(2) + omp_get_wtime()
 !$      call omp_set_num_threads(atmos_nthreads+(conc_nthreads-1)*radiation_nthreads)
 
-<<<<<<< HEAD
         call coupler_update_atmos_model_state(Atm, current_timestep, coupler_chksum_obj, coupler_clocks )
-=======
-        call fms_mpp_clock_begin(coupler_clocks%update_atmos_model_state)
-        call update_atmos_model_state( Atm )
-        if (do_chksum) call coupler_chksum_obj%get_atmos_ice_land_chksums('update_atmos_model_state+', current_timestep)
-        if (do_debug)  call fms_memutils_print_memuse_stats( 'update state')
-        call fms_mpp_clock_end(coupler_clocks%update_atmos_model_state)
->>>>>>> origin/atmos_model-flux_down
 
       enddo fast_integration_loop ! end of na (fast loop)
 

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -345,7 +345,7 @@ program coupler_main
   type  (land_data_type), target :: Land
   type   (ice_data_type), target :: Ice
   ! allow members of ocean type to be aliased (ap)
-  type (ocean_public_type), target  :: Ocean 
+  type (ocean_public_type), target  :: Ocean
   type (ocean_state_type),  pointer :: Ocean_state => NULL()
 
   type(atmos_land_boundary_type), target :: Atmos_land_boundary
@@ -439,7 +439,7 @@ program coupler_main
   call fms_mpp_clock_begin(coupler_clocks%main)         !begin main loop
 
 !-----------------------------------------------------------------------
-!> ocean/slow-ice integration loop 
+!> ocean/slow-ice integration loop
 
   if (check_stocks >= 0) call coupler_flux_init_finish_stocks(Time, Atm, Land, Ice, Ocean_state, &
                                                               coupler_clocks, init_stocks=.True.)
@@ -509,7 +509,7 @@ program coupler_main
       call send_ice_mask_sic(Time)
 
       !-----------------------------------------------------------------------
-      !> atmos/fast-land/fast-ice integration loop 
+      !> atmos/fast-land/fast-ice integration loop
 
       call fms_mpp_clock_begin(coupler_clocks%atmos_loop)
       do na = 1, num_atmos_calls
@@ -525,7 +525,7 @@ program coupler_main
         if (do_flux) call coupler_sfc_boundary_layer(Atm, Land, Ice, Land_ice_atmos_boundary, &
                                                      Time_atmos, current_timestep, coupler_chksum_obj, coupler_clocks)
 
-        
+
 !$OMP   PARALLEL  &
 !$OMP&    NUM_THREADS(conc_nthreads)  &
 !$OMP&    DEFAULT(NONE)  &

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -373,7 +373,7 @@ program coupler_main
   character(len=32) :: timestamp
 
   type(coupler_clock_type)      :: coupler_clocks
-  type(coupler_components_type) :: coupler_components_obj
+  type(coupler_components_type), target :: coupler_components_obj
   type(coupler_chksum_type)     :: coupler_chksum_obj
 
   integer :: outunit

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -694,7 +694,7 @@ program coupler_main
         call coupler_intermediate_restart(Atm, Ice, Ocean, Ocean_state, Ocn_bc_restart, Ice_bc_restart, &
                                           Time, Time_restart, Time_start)
 
-    !-------------- call coupler_summarize_timestep(current_timestep, num_cpld_calls, coupler_chksum_obj, Atm%pe, omp_sec, imb_sec)
+    call coupler_summarize_timestep(current_timestep, num_cpld_calls, coupler_chksum_obj, Atm%pe, omp_sec, imb_sec)
     omp_sec(:)=0.
     imb_sec(:)=0.
 
@@ -703,13 +703,10 @@ program coupler_main
   !-----------------------------------------------------------------------
   call fms_mpp_set_current_pelist()
   call fms_mpp_clock_end(coupler_clocks%main)
-  call fms_mpp_clock_begin(coupler_clocks%termination)
 
   call coupler_end(Atm, Land, Ice, Ocean, Ocean_state, Land_ice_atmos_boundary, Atmos_ice_boundary,&
       Atmos_land_boundary, Ice_ocean_boundary, Ocean_ice_boundary, Ocn_bc_restart, Ice_bc_restart, &
       nc, Time, Time_start, Time_end, coupler_chksum_obj, coupler_clocks)
-
-  call fms_mpp_clock_end(coupler_clocks%termination)
 
   call fms_memutils_print_memuse_stats( 'Memory HiWaterMark', always=.True. )
   call fms_end

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -368,7 +368,7 @@ program coupler_main
   type(FmsNetcdfDomainFile_t), dimension(:), pointer :: Ice_bc_restart => NULL()
   type(FmsNetcdfDomainFile_t), dimension(:), pointer :: Ocn_bc_restart => NULL()
 
-  type(FmsTime_type) :: Time_restart, Time_start, Time_end
+  type(FmsTime_type) :: Time_restart, Time_start, Time_end, Time_restart_current
 
   type(coupler_clock_type)      :: coupler_clocks
   type(coupler_components_type), target :: coupler_components_obj
@@ -428,7 +428,7 @@ program coupler_main
     Ice_ocean_driver_CS, Ice_bc_restart, Ocn_bc_restart, ensemble_pelist, slow_ice_ocean_pelist, &
     conc_nthreads, coupler_clocks, coupler_components_obj, coupler_chksum_obj, &
     Time_step_cpld, Time_step_atmos, Time_atmos, Time_ocean, num_cpld_calls,   &
-    num_atmos_calls, Time, Time_start, Time_end, Time_restart)
+    num_atmos_calls, Time, Time_start, Time_end, Time_restart, Time_restart_current)
 
   if (do_chksum) call coupler_chksum_obj%get_coupler_chksums('coupler_init+', 0)
 
@@ -692,7 +692,7 @@ program coupler_main
     !> write out intermediate restart file when needead.
     if (Time >= Time_restart) &
         call coupler_intermediate_restart(Atm, Ice, Ocean, Ocean_state, Ocn_bc_restart, Ice_bc_restart, &
-                                          Time, Time_restart, Time_start)
+                                          Time, Time_restart, Time_restart_current, Time_start)
 
     call coupler_summarize_timestep(current_timestep, num_cpld_calls, coupler_chksum_obj, Atm%pe, omp_sec, imb_sec)
     omp_sec(:)=0.
@@ -706,7 +706,7 @@ program coupler_main
 
   call coupler_end(Atm, Land, Ice, Ocean, Ocean_state, Land_ice_atmos_boundary, Atmos_ice_boundary,&
       Atmos_land_boundary, Ice_ocean_boundary, Ocean_ice_boundary, Ocn_bc_restart, Ice_bc_restart, &
-      nc, Time, Time_start, Time_end, coupler_chksum_obj, coupler_clocks)
+      nc, Time, Time_start, Time_end, Time_restart_current, coupler_chksum_obj, coupler_clocks)
 
   call fms_memutils_print_memuse_stats( 'Memory HiWaterMark', always=.True. )
   call fms_end

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -372,7 +372,7 @@ program coupler_main
   character(len=32) :: timestamp
 
   type(coupler_clock_type) :: coupler_clocks
-  class(coupler_chksum_type) :: coupler_chksum_obj
+  class(coupler_chksum_type) :: coupler_chksum_ojb
 
   integer :: outunit
   character(len=80) :: text
@@ -550,7 +550,7 @@ program coupler_main
           !      ---- atmosphere dynamics ----
           if (do_atmos) then
             call fms_mpp_clock_begin(coupler_clocks%update_atmos_model_dynamics)
-            call update_atmos_model_dynamics( Atm )
+            call update_atmos_model_dynamics( Atm, chksum%set_id('id', timestep ))
             call fms_mpp_clock_end(coupler_clocks%update_atmos_model_dynamics)
           endif
           if (do_chksum) call atmos_ice_land_chksum('update_atmos_model_dynamics', (nc-1)*num_atmos_calls+na, &

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -345,7 +345,7 @@ program coupler_main
   type  (land_data_type), target :: Land
   type   (ice_data_type), target :: Ice
   ! allow members of ocean type to be aliased (ap)
-  type (ocean_public_type), target  :: Ocean 
+  type (ocean_public_type), target  :: Ocean
   type (ocean_state_type),  pointer :: Ocean_state => NULL()
 
   type(atmos_land_boundary_type), target :: Atmos_land_boundary
@@ -526,7 +526,7 @@ program coupler_main
         if (do_flux) call coupler_sfc_boundary_layer(Atm, Land, Ice, Land_ice_atmos_boundary, &
                                                      Time_atmos, current_timestep, coupler_chksum_obj, coupler_clocks)
 
-        
+
 !$OMP   PARALLEL  &
 !$OMP&    NUM_THREADS(conc_nthreads)  &
 !$OMP&    DEFAULT(NONE)  &

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -674,27 +674,24 @@ program coupler_main
       if (combined_ice_and_ocean) then
         call flux_ice_to_ocean_stocks(Ice)
         call update_slow_ice_and_ocean(ice_ocean_driver_CS, Ice, Ocean_state, Ocean, &
-                      Ice_ocean_boundary, Time_ocean, Time_step_cpld )
+                                       Ice_ocean_boundary, Time_ocean, Time_step_cpld )
       else
-      if (do_chksum) call coupler_chksum_obj%get_ocean_chksums('update_ocean_model-', nc)
-      ! update_ocean_model since fluxes don't change here
-
-      if (do_ocean) &
-        call update_ocean_model( Ice_ocean_boundary, Ocean_state,  Ocean, &
-                                 Time_ocean, Time_step_cpld )
-      endif
-
-      if (do_chksum) call coupler_chksum_obj%get_ocean_chksums('update_ocean_model+', nc)
-      ! Get stocks from "Ice_ocean_boundary" and add them to Ocean stocks.
-      ! This call is just for record keeping of stocks transfer and
-      ! does not modify either Ocean or Ice_ocean_boundary
-      call flux_ocean_from_ice_stocks(Ocean_state, Ocean, Ice_ocean_boundary)
-
-      call fms_diag_send_complete(Time_step_cpld)
-      Time_ocean = Time_ocean +  Time_step_cpld
-      Time = Time_ocean
-
-      call fms_mpp_clock_end(coupler_clocks%ocean)
+        if (do_chksum) call coupler_chksum_obj%get_ocean_chksums('update_ocean_model-', nc)
+        
+        ! update_ocean_model since fluxes don't change here        
+        if (do_ocean) call coupler_update_ocean_model(Ice_ocean_boundary, Ocean_state,  Ocean, &
+                      Time_ocean, Time_step_cpld, current_timestep, coupler_chksum_type)
+        
+        ! Get stocks from "Ice_ocean_boundary" and add them to Ocean stocks.
+        ! This call is just for record keeping of stocks transfer and
+        ! does not modify either Ocean or Ice_ocean_boundary
+        call flux_ocean_from_ice_stocks(Ocean_state, Ocean, Ice_ocean_boundary)
+        
+        call fms_diag_send_complete(Time_step_cpld)
+        Time_ocean = Time_ocean +  Time_step_cpld
+        Time = Time_ocean
+        
+        call fms_mpp_clock_end(coupler_clocks%ocean)
     endif
 
     !--- write out intermediate restart file when needed.

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -438,8 +438,10 @@ program coupler_main
   !> begin main loop
   call fms_mpp_clock_begin(coupler_clocks%main)
 
+  if (check_stocks >= 0) call coupler_flux_init_finish_stocks(Time, Atm, Land, Ice, Ocean_state, &
+                                                              coupler_clocks, init_stocks=.True.)
+      
   !> ocean/slow-ice integration loop
-
   slow_integration_loop : do nc = 1, num_cpld_calls
 
     if (do_chksum) then

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -512,25 +512,15 @@ program coupler_main
       call fms_mpp_clock_begin(coupler_clocks%atmos_loop)
       do na = 1, num_atmos_calls
         if (do_chksum) call atmos_ice_land_chksum('top_of_atmos_loop-', (nc-1)*num_atmos_calls+na, Atm, Land, Ice, &
-                 Land_ice_atmos_boundary, Atmos_ice_boundary, Atmos_land_boundary)
+                                                  Land_ice_atmos_boundary, Atmos_ice_boundary, Atmos_land_boundary)
 
         Time_atmos = Time_atmos + Time_step_atmos
 
-        if (do_atmos) then
-          call fms_mpp_clock_begin(coupler_clocks%atmos_tracer_driver_gather_data)
-          call atmos_tracer_driver_gather_data(Atm%fields, Atm%tr_bot)
-          call fms_mpp_clock_end(coupler_clocks%atmos_tracer_driver_gather_data)
-        endif
+        if (do_atmos) call coupler_atmos_tracer_driver_gather_data(Atm, coupler_clocks)
 
-        if (do_flux) then
-          call fms_mpp_clock_begin(coupler_clocks%sfc_boundary_layer)
-          call sfc_boundary_layer( REAL(dt_atmos), Time_atmos, &
-               Atm, Land, Ice, Land_ice_atmos_boundary )
-          if (do_chksum)  call atmos_ice_land_chksum('sfc+', (nc-1)*num_atmos_calls+na, Atm, Land, Ice, &
-                 Land_ice_atmos_boundary, Atmos_ice_boundary, Atmos_land_boundary)
-          call fms_mpp_clock_end(coupler_clocks%sfc_boundary_layer)
-        endif
-
+        if (do_flux) call coupler_sfc_boundary_layer(Atm, Land, Ice, Land_ice_atmos_boundary, &
+            Atmos_ice_boundary,Atmos_land_boundary, Time_atmos, (nc-1)*num_atmos_calls+na, coupler_clocks)
+        
 !$OMP   PARALLEL  &
 !$OMP&    NUM_THREADS(conc_nthreads)  &
 !$OMP&    DEFAULT(NONE)  &

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -701,6 +701,9 @@ program coupler_main
   enddo slow_integration_loop
   
   !-----------------------------------------------------------------------
+  if( check_stocks >=0 ) call coupler_flux_init_finish_stocks(Time, Atm, Land, Ice, Ocean_state, &
+                                                              coupler_clocks, finish_stocks=.True.)
+
   call fms_mpp_set_current_pelist()
   call fms_mpp_clock_end(coupler_clocks%main)
 

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -434,7 +434,9 @@ program coupler_main
     Time_step_cpld, Time_step_atmos, Time_atmos, Time_ocean, num_cpld_calls,   &
     num_atmos_calls, Time, Time_start, Time_end, Time_restart, Time_restart_current)
 
-  if (do_chksum) call coupler_chksum_obj%get_coupler_chksums('coupler_init+', 0)
+  do_chksum = .True.
+  
+  !if (do_chksum) call coupler_chksum_obj%get_coupler_chksums('coupler_init+', 0)
 
   call fms_mpp_set_current_pelist()
   call fms_mpp_clock_end(coupler_clocks%initialization) !end initialization
@@ -450,7 +452,7 @@ program coupler_main
   do nc = 1, num_cpld_calls
 
     if (do_chksum) then
-      call coupler_chksum_obj%get_coupler_chksums('top_of_coupled_loop+', nc)
+      !call coupler_chksum_obj%get_coupler_chksums('top_of_coupled_loop+', nc)
       call coupler_chksum_obj%get_atmos_ice_land_ocean_chksums('MAIN_LOOP-', nc)
     end if
 
@@ -472,7 +474,7 @@ program coupler_main
     end if
 
     if (do_chksum) then
-      call coupler_chksum_obj%get_coupler_chksums('flux_ocn2ice+', nc)
+      !call coupler_chksum_obj%get_coupler_chksums('flux_ocn2ice+', nc)
       call coupler_chksum_obj%get_atmos_ice_land_ocean_chksums('flux_ocn2ice+', nc)
     end if
 
@@ -802,7 +804,7 @@ program coupler_main
     endif
 
     !--------------
-    if (do_chksum) call coupler_chksum_obj%get_coupler_chksums('MAIN_LOOP+', nc)
+    !if (do_chksum) call coupler_chksum_obj%get_coupler_chksums('MAIN_LOOP+', nc)
     write( text,'(a,i6)' )'Main loop at coupling timestep=', nc
     call fms_memutils_print_memuse_stats(text)
     outunit= fms_mpp_stdout()
@@ -814,6 +816,8 @@ program coupler_main
     imb_sec(:)=0.
     call flush(outunit)
 
+    stop
+    
   enddo
 102 FORMAT(A17,i5,A4,i5,A24,f10.4,A2,f10.4,A3,f10.4,A2,f10.4,A1)
 

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -1399,7 +1399,7 @@ contains
     if (Time_restart_current > Time_start) then
       if ( fms_mpp_pe().EQ.fms_mpp_root_pe()) then
         open(newunit = restart_unit, file=file_res, status='replace', form='formatted')
-        call fms_time_manager_get_date(Time_current_restart, yr,mon,day,hr,min,sec)
+        call fms_time_manager_get_date(Time_restart_current, yr,mon,day,hr,min,sec)
         write(restart_unit, '(6i6,8x,a)' )yr,mon,day,hr,min,sec, &
              'Current intermediate restart time: year, month, day, hour, minute, second'
         close(restart_unit)
@@ -2371,9 +2371,9 @@ contains
     character(len=32) :: timestamp !< Time in string
     integer :: outunit             !< stdout
 
-    Time_restart_current = Time
+    Time_restart_current = Time_current
     
-    timestamp = fms_time_manager_date_to_string(Time)
+    timestamp = fms_time_manager_date_to_string(Time_restart_current)
     outunit= fms_mpp_stdout()
     write(outunit,*) '=> NOTE from program coupler: intermediate restart file is written and ', &
                       trim(timestamp),' is appended as prefix to each restart file name'
@@ -2385,9 +2385,9 @@ contains
     if (Ocean%is_ocean_pe) call ocean_model_restart(Ocean_state, timestamp)
 
     call coupler_restart(Atm, Ice, Ocean, Ocn_bc_restart, Ice_bc_restart, &
-                         Time, Time_restart_current, Time_start, timestamp)
+                         Time_current, Time_restart_current, Time_start, timestamp)
 
-    Time_restart = fms_time_manager_increment_date(Time, restart_interval(1), restart_interval(2), &
+    Time_restart = fms_time_manager_increment_date(Time_current, restart_interval(1), restart_interval(2), &
                    restart_interval(3), restart_interval(4), restart_interval(5), restart_interval(6) )
 
   end subroutine coupler_intermediate_restart

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -1113,6 +1113,7 @@ contains
                                                     Atmos_land_boundary,Atmos_ice_boundary, Land_ice_boundary, &
                                                     Ice_ocean_boundary, Ocean_ice_boundary)
 
+    do_endpoint_chksum = .False.
     if ( do_endpoint_chksum ) then
       call coupler_atmos_ice_land_ocean_chksum('coupler_init+', 0, Atm, Land, Ice, &
           Land_ice_atmos_boundary, Atmos_ice_boundary, Atmos_land_boundary, Ocean, Ice_ocean_boundary)
@@ -1949,7 +1950,7 @@ contains
     call fms_mpp_clock_begin(coupler_clocks%sfc_boundary_layer)
 
     call sfc_boundary_layer( real(dt_atmos), Time_atmos, Atm, Land, Ice, Land_ice_atmos_boundary )
-    if (do_chksum)  call atmos_ice_land_chksum('sfc+', current_time_step, Atm, Land, Ice, &
+    call atmos_ice_land_chksum('sfc+', current_time_step, Atm, Land, Ice, &
         Land_ice_atmos_boundary, coupler_chksum_obj%Atmos_ice_boundary,                   &
         coupler_chksum_obj%Atmos_land_boundary)
     

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -287,7 +287,7 @@ module full_coupler_mod
     type(ice_ocean_boundary_type),  pointer :: Ice_ocean_boundary  !< pointer to Ice_ocean_boundary
     type(ocean_ice_boundary_type),  pointer :: Ocean_ice_boundary  !< pointer to Ocean_ice_boundary
   contains
-    procedure, public :: coupler_components_obj_init
+    procedure, public :: initialize_coupler_components_obj
     procedure, public :: get_component  !< subroutine to retrieve the requested component of an object of this type
     procedure, public :: set_component  !< subroutine to set requested component of an object of this type
   end type coupler_components_type
@@ -299,7 +299,7 @@ module full_coupler_mod
     private
     type(coupler_components_type), pointer :: components
   contains
-    procedure, public :: coupler_chksum_obj_init !< associates the pointers above to model components
+    procedure, public :: initialize_coupler_chksum_obj !< associates the pointers above to model components
     procedure, public :: get_components_obj !< subroutine to retrieve the requested component of an object of this type
     procedure, public :: set_components_obj !< subroutine to set components object
     procedure, public :: get_atmos_ice_land_ocean_chksums !< subroutine to compute chksums for atmos - ocean
@@ -1127,11 +1127,11 @@ contains
 !-----------------------------------------------------------------------
 
     !> Initialize coupler_components_obj memebers to point to model components
-    call coupler_components_obj%coupler_components_obj_init(Atm, Land, Ice, Ocean, Land_ice_atmos_boundary, &
+    call coupler_components_obj%initialize_coupler_components_obj(Atm, Land, Ice, Ocean, Land_ice_atmos_boundary,&
         Atmos_land_boundary, Atmos_ice_boundary, Land_ice_boundary, Ice_ocean_boundary, Ocean_ice_boundary)
 
     !> Initialize coupler_chksum_obj
-    call coupler_chksum_obj%coupler_chksum_obj_init(coupler_components_obj)
+    call coupler_chksum_obj%initialize_coupler_chksum_obj(coupler_components_obj)
 
     if ( do_endpoint_chksum ) then
       call coupler_chksum_obj%get_atmos_ice_land_ocean_chksums('coupler_init+', 0)
@@ -1154,8 +1154,8 @@ contains
 !#######################################################################
 
   !> This subroutine associates the pointer in an object of coupler_components_type to the model components
-  subroutine coupler_components_obj_init(this, Atm, Land, Ice, Ocean, Land_ice_atmos_boundary, Atmos_land_boundary, &
-                                         Atmos_ice_boundary, Land_ice_boundary, Ice_ocean_boundary, Ocean_ice_boundary)
+  subroutine initialize_coupler_components_obj(this, Atm, Land, Ice, Ocean, Land_ice_atmos_boundary, &
+      Atmos_land_boundary, Atmos_ice_boundary, Land_ice_boundary, Ice_ocean_boundary, Ocean_ice_boundary)
 
     implicit none
     class(coupler_components_type), intent(inout) :: this !< self
@@ -1181,7 +1181,7 @@ contains
     this%Ice_ocean_boundary => Ice_ocean_boundary
     this%Ocean_ice_boundary => Ocean_ice_boundary
 
-  end subroutine coupler_components_obj_init
+  end subroutine initialize_coupler_components_obj
 
   !> Function get_component returns the requested component in the coupler_components_type object
   !! Users are required to provide the component to be retrieved as an input argument.  For example,
@@ -1246,7 +1246,7 @@ contains
   end subroutine set_component
 
   !> This subroutine associates the pointer in an object of coupler_chksum_type to the component models
-  subroutine coupler_chksum_obj_init(this, components_obj)
+  subroutine initialize_coupler_chksum_obj(this, components_obj)
 
     implicit none
     class(coupler_chksum_type), intent(inout) :: this
@@ -1254,7 +1254,7 @@ contains
 
     this%components = components_obj
 
-  end subroutine coupler_chksum_obj_init
+  end subroutine initialize_coupler_chksum_obj
 
   !> This subroutine retrieves coupler_chksum_obj%components_obj
   subroutine get_components_obj(this, components_obj)

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -1897,7 +1897,7 @@ contains
     type(coupler_clock_type), intent(in) :: coupler_clocks !< coupler_clocks
                                                                                 
     call fms_mpp_clock_begin(coupler_clocks%sfc_boundary_layer)
-    call sfc_boundary_layer( dt_atmos, Time_atmos, Atm, Land, Ice, Land_ice_atmos_boundary )
+    call sfc_boundary_layer( real(dt_atmos), Time_atmos, Atm, Land, Ice, Land_ice_atmos_boundary )
     if (do_chksum)  call atmos_ice_land_chksum('sfc+', current_time_step, Atm, Land, Ice, &
                                                Land_ice_atmos_boundary, Atmos_ice_boundary, Atmos_land_boundary)
     call fms_mpp_clock_end(coupler_clocks%sfc_boundary_layer)

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -133,7 +133,7 @@ module full_coupler_mod
   public :: coupler_update_land_model_fast, coupler_update_ice_model_fast
   public :: coupler_flux_up_to_atmos, coupler_update_atmos_model_up
   public :: coupler_flux_atmos_to_ocean, coupler_update_atmos_model_state
-  
+
   public :: coupler_clock_type, coupler_chksum_type
 
 #include <file_version.fh>
@@ -276,9 +276,9 @@ module full_coupler_mod
     integer :: ocean_model_init
     integer :: flux_exchange_init
   end type coupler_clock_type
-  
+
   type coupler_chksum_type
-    type(atmos_data_type), pointer :: Atm    
+    type(atmos_data_type), pointer :: Atm
     type(land_data_type),  pointer :: Land
     type(ice_data_type),   pointer :: Ice
     type(ocean_public_type), pointer :: Ocean
@@ -291,7 +291,7 @@ module full_coupler_mod
   contains
     procedure :: coupler_chksum_obj_init
   end type coupler_chksum_type
-  
+
   character(len=80) :: text
   character(len=48), parameter :: mod_name = 'coupler_main_mod'
 
@@ -1148,7 +1148,7 @@ contains
     type(land_ice_boundary_type),   target, intent(in) :: Land_ice_boundary
     type(ice_ocean_boundary_type),  target, intent(in) :: Ice_ocean_boundary
     type(ocean_ice_boundary_type),  target, intent(in) :: Ocean_ice_boundary
-    
+
     self%Atm => Atm
     self%Land => Land
     self%Ice => Ice
@@ -1158,11 +1158,11 @@ contains
     self%Atmos_ice_boundary => Atmos_ice_boundary
     self%Land_ice_boundary => Land_ice_boundary
     self%Ice_ocean_boundary => Ice_ocean_boundary
-    self%Ocean_ice_boundary => Ocean_ice_boundary   
+    self%Ocean_ice_boundary => Ocean_ice_boundary
 
   end subroutine coupler_chksum_obj_init
 
-  
+
   subroutine coupler_end(Atm, Land, Ice, Ocean, Ocean_state, Land_ice_atmos_boundary, Atmos_ice_boundary,&
                          Atmos_land_boundary, Ice_ocean_boundary, Ocean_ice_boundary, Ocn_bc_restart, &
                          Ice_bc_restart, Time, Time_start, Time_end, Time_restart_current)
@@ -1349,7 +1349,7 @@ contains
   end subroutine coupler_restart
 
 !--------------------------------------------------------------------------
-  
+
 !> \brief Print out checksums for several atm, land and ice variables
   subroutine coupler_chksum(id, timestep, Atm, Land, Ice)
 
@@ -1922,8 +1922,8 @@ contains
   subroutine coupler_atmos_tracer_driver_gather_data(Atm, coupler_clocks)
 
     implicit none
-    
-    type(atmos_data_type), intent(inout)    :: Atm !< Atm 
+
+    type(atmos_data_type), intent(inout)    :: Atm !< Atm
     type(coupler_clock_type), intent(inout) :: coupler_clocks !< coupler_clocks
     call fms_mpp_clock_begin(coupler_clocks%atmos_tracer_driver_gather_data)
     call atmos_tracer_driver_gather_data(Atm%fields, Atm%tr_bot)
@@ -1945,16 +1945,16 @@ contains
     integer, intent(in)            :: current_timestep !< (nc-1)*num_atmos_cal + na
     type(coupler_chksum_type), intent(in)   :: coupler_chksum_obj
     type(coupler_clock_type), intent(inout) :: coupler_clocks !< coupler_clocks
-                                                                                
+
     call fms_mpp_clock_begin(coupler_clocks%sfc_boundary_layer)
 
     call sfc_boundary_layer( real(dt_atmos), Time_atmos, Atm, Land, Ice, Land_ice_atmos_boundary )
     if (do_chksum)  call atmos_ice_land_chksum('sfc+', current_timestep, Atm, Land, Ice, &
         Land_ice_atmos_boundary, coupler_chksum_obj%Atmos_ice_boundary,                  &
         coupler_chksum_obj%Atmos_land_boundary)
-    
+
     call fms_mpp_clock_end(coupler_clocks%sfc_boundary_layer)
-    
+
   end subroutine coupler_sfc_boundary_layer
 
   !> This subroutine calls update_atmos_model_dynamics.  Clocks are set for runtime statistics.  Chksums
@@ -1963,10 +1963,10 @@ contains
 
     implicit none
     type(atmos_data_type), intent(inout) :: Atm !< Atm
-    integer,                   intent(in) :: current_timestep   !< Current timestep 
+    integer,                   intent(in) :: current_timestep   !< Current timestep
     type(coupler_chksum_type), intent(in) :: coupler_chksum_obj !< coupler_chksum_obj pointing to component types
     type(coupler_clock_type),  intent(inout) :: coupler_clocks  !< coupler_clocks
-    
+
     call fms_mpp_clock_begin(coupler_clocks%update_atmos_model_dynamics)
     call update_atmos_model_dynamics(Atm)
     call fms_mpp_clock_end(coupler_clocks%update_atmos_model_dynamics)
@@ -1976,7 +1976,7 @@ contains
         coupler_chksum_obj%Atmos_ice_boundary, coupler_chksum_obj%Atmos_land_boundary)
 
     if (do_debug)  call fms_memutils_print_memuse_stats( 'update dyn')
-    
+
   end subroutine coupler_update_atmos_model_dynamics
 
   !> This subroutine calls update_atmos_model_radiation.  Clocks are set for runtime statistics.
@@ -1990,11 +1990,11 @@ contains
     type(atmos_data_type), intent(inout) :: Atm
     type(land_ice_atmos_boundary_type), intent(inout) :: Land_ice_atmos_boundary
     type(coupler_clock_type),         intent(inout) :: coupler_clocks     !< coupler_clocks
-    integer,                   optional, intent(in) :: current_timestep   !< Current timestep 
+    integer,                   optional, intent(in) :: current_timestep   !< Current timestep
     type(coupler_chksum_type), optional, intent(in) :: coupler_chksum_obj !< points to component types
 
     character(128) :: memuse_stats_id = 'update serial rad'
-    
+
     call fms_mpp_clock_begin(coupler_clocks%radiation)
     call update_atmos_model_radiation( Land_ice_atmos_boundary, Atm )
     call fms_mpp_clock_end(coupler_clocks%radiation)
@@ -2006,7 +2006,7 @@ contains
                                        Atm, coupler_chksum_obj%Land, coupler_chksum_obj%Ice, Land_ice_atmos_boundary,  &
                                        coupler_chksum_obj%Atmos_ice_boundary, coupler_chksum_obj%Atmos_land_boundary)
     end if
-    
+
     if (do_debug) then
       if(do_concurrent_radiation) memuse_stats_id = 'update concurrent rad'
       call fms_memutils_print_memuse_stats(trim(memuse_stats_id))
@@ -2022,7 +2022,7 @@ contains
     implicit none
     type(atmos_data_type), intent(inout) :: Atm  !< Atm
     type(land_ice_atmos_boundary_type), intent(inout) :: Land_ice_atmos_boundary !<Land ice_atmos_boundary
-    integer,                   intent(in) :: current_timestep   !< Current timestep 
+    integer,                   intent(in) :: current_timestep   !< Current timestep
     type(coupler_chksum_type), intent(in) :: coupler_chksum_obj !< coupler_chksum_obj pointing to component types
     type(coupler_clock_type),  intent(inout) :: coupler_clocks  !< coupler_clocks
 
@@ -2053,7 +2053,7 @@ contains
     type(FmsTime_type), intent(in) :: Time_atmos       !<Time_atmos FmsTime_type containing time in seconds
     integer,            intent(in) :: current_timestep !< current_timestep
     type(coupler_clock_type), intent(inout) :: coupler_clocks !<coupler_clocks
-    
+
     call fms_mpp_clock_begin(coupler_clocks%flux_down_from_atmos)
     call flux_down_from_atmos(Time_atmos, Atm, Land, Ice, Land_ice_atmos_boundary, &
                               Atmos_land_boundary, Atmos_ice_boundary )
@@ -2061,7 +2061,7 @@ contains
 
     if (do_chksum) call atmos_ice_land_chksum('flux_down_from_atmos+', current_timestep, Atm, Land, &
                    Ice, Land_ice_atmos_boundary, Atmos_ice_boundary, Atmos_land_boundary)
-          
+
   end subroutine coupler_flux_down_from_atmos
 
   !> This subroutine calls update_land_model_fast.  Clocks are set for runtime statistics.  Chksums
@@ -2079,17 +2079,17 @@ contains
 
     call fms_mpp_clock_begin(coupler_clocks%update_land_model_fast) !< current pelist=Atm%pelist
     if (land_npes .NE. atmos_npes) call fms_mpp_set_current_pelist(Land%pelist)
-    
+
     call update_land_model_fast( Atmos_land_boundary, Land )
 
     if (land_npes .NE. atmos_npes) call fms_mpp_set_current_pelist(atm_pelist)
     call fms_mpp_clock_end(coupler_clocks%update_land_model_fast)
-    
+
     if (do_chksum) call atmos_ice_land_chksum('update_land_fast+', current_timestep, coupler_chksum_obj%Atm, Land, &
         coupler_chksum_obj%Ice, coupler_chksum_obj%Land_ice_atmos_boundary, coupler_chksum_obj%Atmos_ice_boundary, &
         coupler_chksum_obj%Atmos_land_boundary)
     if (do_debug)  call fms_memutils_print_memuse_stats( 'update land')
-    
+
   end subroutine coupler_update_land_model_fast
 
   !> This subroutine calls update_ice_model_fast.  Clocks are set for runtime statistics.  Chksums
@@ -2109,7 +2109,7 @@ contains
     if (ice_npes .NE. atmos_npes)call fms_mpp_set_current_pelist(Ice%fast_pelist)
 
     call update_ice_model_fast( Atmos_ice_boundary, Ice )
-    
+
     if (ice_npes .NE. atmos_npes) call fms_mpp_set_current_pelist(atm_pelist)
     call fms_mpp_clock_end(coupler_clocks%update_ice_model_fast)
 
@@ -2124,7 +2124,7 @@ contains
   !! are computed if do_chksum is .True.
   subroutine coupler_flux_up_to_atmos(Land, Ice, Land_ice_atmos_boundary, Atmos_land_boundary, Atmos_ice_boundary,&
                                       Time_atmos, current_timestep, coupler_chksum_obj, coupler_clocks)
-    
+
     implicit none
     type(land_data_type), intent(inout) :: Land !< Land
     type(ice_data_type),  intent(inout) :: Ice  !< Ice
@@ -2141,8 +2141,8 @@ contains
     call fms_mpp_clock_end(coupler_clocks%flux_up_to_atmos)
 
     if (do_chksum) call atmos_ice_land_chksum('flux_up2atmos+', current_timestep, coupler_chksum_obj%Atm, &
-                   Land, Ice, Land_ice_atmos_boundary, Atmos_ice_boundary, Atmos_land_boundary)   
-    
+                   Land, Ice, Land_ice_atmos_boundary, Atmos_ice_boundary, Atmos_land_boundary)
+
   end subroutine coupler_flux_up_to_atmos
 
   !> This subroutine calls update_atmos_model_up.  Clocks are set for runtime statistics.  Chksums
@@ -2156,7 +2156,7 @@ contains
     integer,                  intent(in) :: current_timestep   !< current_timestep
     type(coupler_chksum_type),intent(in) :: coupler_chksum_obj !< points to component types
     type(coupler_clock_type), intent(inout) :: coupler_clocks  !< coupler_clocks
-    
+
     call fms_mpp_clock_begin(coupler_clocks%update_atmos_model_up)
     call update_atmos_model_up(Land_ice_atmos_boundary, Atm)
     call fms_mpp_clock_end(coupler_clocks%update_atmos_model_up)
@@ -2164,8 +2164,8 @@ contains
     if (do_chksum) call atmos_ice_land_chksum('update_atmos_up+', current_timestep, Atm, coupler_chksum_obj%Land, &
                    coupler_chksum_obj%Ice, Land_ice_atmos_boundary, &
                    coupler_chksum_obj%Atmos_ice_boundary, coupler_chksum_obj%Atmos_land_boundary)
-    if (do_debug) call fms_memutils_print_memuse_stats( 'update up')    
-    
+    if (do_debug) call fms_memutils_print_memuse_stats( 'update up')
+
   end subroutine coupler_update_atmos_model_up
 
   !> This subroutine calls flux_atmos_to_ocean and calls flux_ex_arrays_dealloc
@@ -2179,7 +2179,7 @@ contains
 
     call flux_atmos_to_ocean(Time_atmos, Atm, Atmos_ice_boundary, Ice)
     call flux_ex_arrays_dealloc
-    
+
   end subroutine coupler_flux_atmos_to_ocean
 
   subroutine coupler_update_atmos_model_state(Atm, current_timestep, coupler_chksum_obj, coupler_clocks)
@@ -2193,12 +2193,12 @@ contains
     call fms_mpp_clock_begin(coupler_clocks%update_atmos_model_state)
     call update_atmos_model_state( Atm )
     call fms_mpp_clock_end(coupler_clocks%update_atmos_model_state)
-    
+
     if (do_chksum) call atmos_ice_land_chksum('update_atmos_model_state+', current_timestep, Atm,    &
                    coupler_chksum_obj%Land, coupler_chksum_obj%Ice, coupler_chksum_obj%Land_ice_atmos_boundary, &
                    coupler_chksum_obj%Atmos_ice_boundary, coupler_chksum_obj%Atmos_land_boundary)
     if (do_debug)  call fms_memutils_print_memuse_stats( 'update state')
-    
+
   end subroutine coupler_update_atmos_model_state
-  
+
 end module full_coupler_mod

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -1347,18 +1347,20 @@ contains
 
     implicit none
 
-    type(atmos_data_type),   intent(inout) :: Atm
-    type(ice_data_type),     intent(inout) :: Ice
-    type(ocean_public_type), intent(inout) :: Ocean
+    type(atmos_data_type),   intent(inout) :: Atm  !< Atm
+    type(ice_data_type),     intent(inout) :: Ice  !< Ice
+    type(ocean_public_type), intent(inout) :: Ocean !< Ocean
 
-    type(FmsNetcdfDomainFile_t), dimension(:), pointer, intent(inout) :: Ocn_bc_restart
-    type(FmsNetcdfDomainFile_t), dimension(:), pointer, intent(inout) :: Ice_bc_restart
+    type(FmsNetcdfDomainFile_t), dimension(:), pointer, intent(inout) :: Ocn_bc_restart !< required for restarts
+    type(FmsNetcdfDomainFile_t), dimension(:), pointer, intent(inout) :: Ice_bc_restart !< required for restarts
 
+    !> Restart files will be written when Time=>Time_restart.  Time_restart is incremented by restart_interval
+    !! Time_restart_current records the current timestep the restart file is being written.
+    !! Time_restart_current does not necessary = Time_restart.    
     type(FmsTime_type),  intent(in)  :: Time_current, Time_restart_current, Time_start
-    character(len=*), intent(in),  optional :: time_stamp
+    character(len=*), intent(in),  optional :: time_stamp !< time_stamp for restart
 
     character(len=128) :: file_run, file_res
-
     integer :: yr, mon, day, hr, min, sec, date(6), n
     integer ::  num_ice_bc_restart, num_ocn_bc_restart
     integer :: restart_unit !< Unit for the coupler restart file

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -132,7 +132,7 @@ module full_coupler_mod
 
   public :: coupler_generate_sfc_xgrid
   public :: coupler_atmos_tracer_driver_gather_data, coupler_sfc_boundary_layer
-  
+
   public :: coupler_clock_type, coupler_chksum_type
 
 #include <file_version.fh>
@@ -276,9 +276,9 @@ module full_coupler_mod
     integer :: ocean_model_init
     integer :: flux_exchange_init
   end type coupler_clock_type
-  
+
   type coupler_chksum_type
-    type(atmos_data_type), pointer :: Atm    
+    type(atmos_data_type), pointer :: Atm
     type(land_data_type),  pointer :: Land
     type(ice_data_type),   pointer :: Ice
     type(ocean_public_type), pointer :: Ocean
@@ -291,7 +291,7 @@ module full_coupler_mod
   contains
     procedure :: coupler_chksum_obj_init
   end type coupler_chksum_type
-  
+
   character(len=80) :: text
   character(len=48), parameter :: mod_name = 'coupler_main_mod'
 
@@ -1149,7 +1149,7 @@ contains
     type(land_ice_boundary_type),   target, intent(in) :: Land_ice_boundary
     type(ice_ocean_boundary_type),  target, intent(in) :: Ice_ocean_boundary
     type(ocean_ice_boundary_type),  target, intent(in) :: Ocean_ice_boundary
-    
+
     self%Atm => Atm
     self%Land => Land
     self%Ice => Ice
@@ -1159,11 +1159,11 @@ contains
     self%Atmos_ice_boundary => Atmos_ice_boundary
     self%Land_ice_boundary => Land_ice_boundary
     self%Ice_ocean_boundary => Ice_ocean_boundary
-    self%Ocean_ice_boundary => Ocean_ice_boundary   
+    self%Ocean_ice_boundary => Ocean_ice_boundary
 
   end subroutine coupler_chksum_obj_init
 
-  
+
   subroutine coupler_end(Atm, Land, Ice, Ocean, Ocean_state, Land_ice_atmos_boundary, Atmos_ice_boundary,&
                          Atmos_land_boundary, Ice_ocean_boundary, Ocean_ice_boundary, Ocn_bc_restart, &
                          Ice_bc_restart, Time, Time_start, Time_end, Time_restart_current)
@@ -1350,7 +1350,7 @@ contains
   end subroutine coupler_restart
 
 !--------------------------------------------------------------------------
-  
+
 !> \brief Print out checksums for several atm, land and ice variables
   subroutine coupler_chksum(id, timestep, Atm, Land, Ice)
 
@@ -1923,8 +1923,8 @@ contains
   subroutine coupler_atmos_tracer_driver_gather_data(Atm, coupler_clocks)
 
     implicit none
-    
-    type(atmos_data_type), intent(inout)    :: Atm !< Atm 
+
+    type(atmos_data_type), intent(inout)    :: Atm !< Atm
     type(coupler_clock_type), intent(inout) :: coupler_clocks !< coupler_clocks
     call fms_mpp_clock_begin(coupler_clocks%atmos_tracer_driver_gather_data)
     call atmos_tracer_driver_gather_data(Atm%fields, Atm%tr_bot)
@@ -1946,17 +1946,17 @@ contains
     integer, intent(in)            :: current_time_step    !< (nc-1)*num_atmos_cal + na
     type(coupler_chksum_type), intent(in)   :: coupler_chksum_obj
     type(coupler_clock_type), intent(inout) :: coupler_clocks !< coupler_clocks
-                                                                                
+
     call fms_mpp_clock_begin(coupler_clocks%sfc_boundary_layer)
 
     call sfc_boundary_layer( real(dt_atmos), Time_atmos, Atm, Land, Ice, Land_ice_atmos_boundary )
     call atmos_ice_land_chksum('sfc+', current_time_step, Atm, Land, Ice, &
         Land_ice_atmos_boundary, coupler_chksum_obj%Atmos_ice_boundary,                   &
         coupler_chksum_obj%Atmos_land_boundary)
-    
+
     call fms_mpp_clock_end(coupler_clocks%sfc_boundary_layer)
-    
+
   end subroutine coupler_sfc_boundary_layer
-  
-  
+
+
 end module full_coupler_mod

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -277,21 +277,24 @@ module full_coupler_mod
     integer :: flux_exchange_init
   end type coupler_clock_type
 
+  !> The purpose of objects of coupler_chksum_type is to simplify the list
+  !! of arguments required for chksum related subroutines in full_coupler_mod.
+  !! The members of this type point to the model components 
   type coupler_chksum_type
     private
-    type(atmos_data_type), pointer :: Atm
-    type(land_data_type),  pointer :: Land
-    type(ice_data_type),   pointer :: Ice
-    type(ocean_public_type), pointer :: Ocean
-    type(land_ice_atmos_boundary_type), pointer :: Land_ice_atmos_boundary
-    type(atmos_land_boundary_type), pointer :: Atmos_land_boundary
-    type(atmos_ice_boundary_type),  pointer :: Atmos_ice_boundary
-    type(land_ice_boundary_type),   pointer :: Land_ice_boundary
-    type(ice_ocean_boundary_type),  pointer :: Ice_ocean_boundary
-    type(ocean_ice_boundary_type),  pointer :: Ocean_ice_boundary
+    type(atmos_data_type), pointer :: Atm  !< pointer to Atm 
+    type(land_data_type),  pointer :: Land !< pointer to Land
+    type(ice_data_type),   pointer :: Ice  !< pointer to Ice
+    type(ocean_public_type), pointer :: Ocean  !< pointer to Ocean
+    type(land_ice_atmos_boundary_type), pointer :: Land_ice_atmos_boundary !< pointer to Land_ice_atmos_boundary
+    type(atmos_land_boundary_type), pointer :: Atmos_land_boundary !< pointer to Atmos_land_boundary
+    type(atmos_ice_boundary_type),  pointer :: Atmos_ice_boundary  !< pointer to Atmos_ice_boundary
+    type(land_ice_boundary_type),   pointer :: Land_ice_boundary   !< pointer to Land_ice_boundary
+    type(ice_ocean_boundary_type),  pointer :: Ice_ocean_boundary  !< pointer to Ice_ocean_boundary
+    type(ocean_ice_boundary_type),  pointer :: Ocean_ice_boundary  !< pointer to Ocean_ice_boundary
   contains
-    procedure, public :: coupler_chksum_obj_init
-    procedure, public :: get_component
+    procedure, public :: coupler_chksum_obj_init !< associates the pointers above to model components
+    procedure, public :: get_component  !< subroutine to retrieve the requested component of an object of this type
   end type coupler_chksum_type
 
   character(len=80) :: text
@@ -1134,21 +1137,23 @@ contains
   end subroutine coupler_init
 
 !#######################################################################
+
+  !> This subroutine associates the pointer in an object of coupler_chksum_type to the component models 
   subroutine coupler_chksum_obj_init(this, Atm, Land, Ice, Ocean, Land_ice_atmos_boundary, Atmos_land_boundary, &
                                      Atmos_ice_boundary, Land_ice_boundary, Ice_ocean_boundary, Ocean_ice_boundary)
 
     implicit none
-    class(coupler_chksum_type), intent(inout) :: this
-    type(atmos_data_type), target, intent(in) :: Atm
-    type(land_data_type),  target, intent(in) :: Land
-    type(ice_data_type),   target, intent(in) :: Ice
-    type(ocean_public_type), target, intent(in) :: Ocean
-    type(land_ice_atmos_boundary_type), target, intent(in) :: Land_ice_atmos_boundary
-    type(atmos_land_boundary_type), target, intent(in) :: Atmos_land_boundary
-    type(atmos_ice_boundary_type),  target, intent(in) :: Atmos_ice_boundary
-    type(land_ice_boundary_type),   target, intent(in) :: Land_ice_boundary
-    type(ice_ocean_boundary_type),  target, intent(in) :: Ice_ocean_boundary
-    type(ocean_ice_boundary_type),  target, intent(in) :: Ocean_ice_boundary
+    class(coupler_chksum_type), intent(inout) :: this !< self
+    type(atmos_data_type), target, intent(in) :: Atm  !< Atm
+    type(land_data_type),  target, intent(in) :: Land !< Land
+    type(ice_data_type),   target, intent(in) :: Ice  !< Ice
+    type(ocean_public_type), target, intent(in) :: Ocean !< Ocean
+    type(land_ice_atmos_boundary_type), target, intent(in) :: Land_ice_atmos_boundary !< Land_ice_atmos_boundary
+    type(atmos_land_boundary_type), target, intent(in) :: Atmos_land_boundary !< Atmos_land_boundary
+    type(atmos_ice_boundary_type),  target, intent(in) :: Atmos_ice_boundary  !< Atmos_ice_boundary
+    type(land_ice_boundary_type),   target, intent(in) :: Land_ice_boundary   !< Land_ice_boundary
+    type(ice_ocean_boundary_type),  target, intent(in) :: Ice_ocean_boundary  !< Ice_ocean_boundary
+    type(ocean_ice_boundary_type),  target, intent(in) :: Ocean_ice_boundary  !< Ocean_ice_boundary
 
     this%Atm => Atm
     this%Land => Land

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -289,7 +289,6 @@ module full_coupler_mod
   contains
     procedure, public :: initialize_coupler_components_obj
     procedure, public :: get_component  !< subroutine to retrieve the requested component of an object of this type
-    procedure, public :: set_component  !< subroutine to set requested component of an object of this type
   end type coupler_components_type
 
   !> The purpose of objects of coupler_chksum_type is to simplify the list
@@ -301,7 +300,6 @@ module full_coupler_mod
   contains
     procedure, public :: initialize_coupler_chksum_obj !< associates the pointers above to model components
     procedure, public :: get_components_obj !< subroutine to retrieve the requested component of an object of this type
-    procedure, public :: set_components_obj !< subroutine to set components object
     procedure, public :: get_atmos_ice_land_ocean_chksums !< subroutine to compute chksums for atmos - ocean
     procedure, public :: get_atmos_ice_land_chksums !< subroutine to compute chksums for atmos_ice_land
     procedure, public :: get_slow_ice_chksums       !< subroutine to compute chskums for slow_ice
@@ -1216,37 +1214,6 @@ contains
 
   end subroutine get_component
 
-  !> Function set_component sets the requested component in the coupler_components_type object
-  !! Users are required to provide the component to be set as an input argument.  For example,
-  !! coupler_components_obj%get_component(Atm) will set coupler_components_obj%Atm = Atm
-  subroutine set_component(this, set_this_component )
-
-    implicit none
-    class(coupler_components_type), intent(inout) :: this !< the coupler_components_type object
-    class(*), intent(in) :: set_this_component  !< requested component to be be set.
-                            !! set_this_component can be of type atmos_data_type, land_data_type, ice_data_type,
-                            !! ocean_public_type, land_ice_atmos_boundary_type, atmos_land_boundary_type,
-                            !! atmos_ice_boundary_type, land_ice_boundary_type, ice_ocean_boundary_type,
-                            !! ocean_ice_boundary_type
-
-    select type(set_this_component)
-    type is(atmos_data_type)   ; this%Atm  = set_this_component
-    type is(land_data_type)    ; this%Land = set_this_component
-    type is(ice_data_type)     ; this%Ice  = set_this_component
-    type is(ocean_public_type) ; this%Ocean = set_this_component
-    type is(land_ice_atmos_boundary_type) ; this%Land_ice_atmos_boundary = set_this_component
-    type is(atmos_land_boundary_type) ; this%Atmos_land_boundary = set_this_component
-    type is(atmos_ice_boundary_type)  ; this%Atmos_ice_boundary = set_this_component
-    type is(land_ice_boundary_type)   ; this%Land_ice_boundary  = set_this_component
-    type is(ice_ocean_boundary_type)  ; this%Ice_ocean_boundary = set_this_component
-    type is(ocean_ice_boundary_type)  ; this%Ocean_ice_boundary = set_this_component
-    class default
-      call fms_mpp_error(FATAL, "failure setting component in coupler_components_type object, &
-                         cannot recognize the type of requested component")
-    end select
-
-  end subroutine set_component
-
   !> This subroutine associates the pointer in an object of coupler_chksum_type to the component models
   subroutine initialize_coupler_chksum_obj(this, components_obj)
 
@@ -1269,18 +1236,6 @@ contains
     components_obj = this%components
 
   end subroutine get_components_obj
-
-  !> This subroutine set coupler_chksum_obj%components_obj
-  subroutine set_components_obj(this, components_obj)
-
-    implicit none
-
-    class(coupler_chksum_type), intent(inout) :: this  !< coupler_chksum_type
-    type(coupler_components_type), intent(in) :: components_obj !< coupler_components_type to be used
-
-    this%components = components_obj
-
-  end subroutine set_components_obj
 
   !> This subroutine finalizes the run
   subroutine coupler_end(Atm, Land, Ice, Ocean, Ocean_state, Land_ice_atmos_boundary, Atmos_ice_boundary,&

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -276,9 +276,9 @@ module full_coupler_mod
     integer :: ocean_model_init
     integer :: flux_exchange_init
   end type coupler_clock_type
-  
+
   type coupler_chksum_type
-    type(atmos_data_type), pointer :: Atm    
+    type(atmos_data_type), pointer :: Atm
     type(land_data_type),  pointer :: Land
     type(ice_data_type),   pointer :: Ice
     type(ocean_public_type), pointer :: Ocean
@@ -291,7 +291,7 @@ module full_coupler_mod
   contains
     procedure :: coupler_chksum_obj_init
   end type coupler_chksum_type
-  
+
   character(len=80) :: text
   character(len=48), parameter :: mod_name = 'coupler_main_mod'
 
@@ -1148,7 +1148,7 @@ contains
     type(land_ice_boundary_type),   target, intent(in) :: Land_ice_boundary
     type(ice_ocean_boundary_type),  target, intent(in) :: Ice_ocean_boundary
     type(ocean_ice_boundary_type),  target, intent(in) :: Ocean_ice_boundary
-    
+
     self%Atm => Atm
     self%Land => Land
     self%Ice => Ice
@@ -1158,11 +1158,11 @@ contains
     self%Atmos_ice_boundary => Atmos_ice_boundary
     self%Land_ice_boundary => Land_ice_boundary
     self%Ice_ocean_boundary => Ice_ocean_boundary
-    self%Ocean_ice_boundary => Ocean_ice_boundary   
+    self%Ocean_ice_boundary => Ocean_ice_boundary
 
   end subroutine coupler_chksum_obj_init
 
-  
+
   subroutine coupler_end(Atm, Land, Ice, Ocean, Ocean_state, Land_ice_atmos_boundary, Atmos_ice_boundary,&
                          Atmos_land_boundary, Ice_ocean_boundary, Ocean_ice_boundary, Ocn_bc_restart, &
                          Ice_bc_restart, Time, Time_start, Time_end, Time_restart_current)
@@ -1349,7 +1349,7 @@ contains
   end subroutine coupler_restart
 
 !--------------------------------------------------------------------------
-  
+
 !> \brief Print out checksums for several atm, land and ice variables
   subroutine coupler_chksum(id, timestep, Atm, Land, Ice)
 
@@ -1922,8 +1922,8 @@ contains
   subroutine coupler_atmos_tracer_driver_gather_data(Atm, coupler_clocks)
 
     implicit none
-    
-    type(atmos_data_type), intent(inout)    :: Atm !< Atm 
+
+    type(atmos_data_type), intent(inout)    :: Atm !< Atm
     type(coupler_clock_type), intent(inout) :: coupler_clocks !< coupler_clocks
     call fms_mpp_clock_begin(coupler_clocks%atmos_tracer_driver_gather_data)
     call atmos_tracer_driver_gather_data(Atm%fields, Atm%tr_bot)
@@ -1945,16 +1945,16 @@ contains
     integer, intent(in)            :: current_timestep !< (nc-1)*num_atmos_cal + na
     type(coupler_chksum_type), intent(in)   :: coupler_chksum_obj
     type(coupler_clock_type), intent(inout) :: coupler_clocks !< coupler_clocks
-                                                                                
+
     call fms_mpp_clock_begin(coupler_clocks%sfc_boundary_layer)
 
     call sfc_boundary_layer( real(dt_atmos), Time_atmos, Atm, Land, Ice, Land_ice_atmos_boundary )
     if (do_chksum)  call atmos_ice_land_chksum('sfc+', current_timestep, Atm, Land, Ice, &
         Land_ice_atmos_boundary, coupler_chksum_obj%Atmos_ice_boundary,                  &
         coupler_chksum_obj%Atmos_land_boundary)
-    
+
     call fms_mpp_clock_end(coupler_clocks%sfc_boundary_layer)
-    
+
   end subroutine coupler_sfc_boundary_layer
 
   !> This subroutine calls update_atmos_model_dynamics.  Clocks are set for runtime statistics.  Chksums
@@ -1963,10 +1963,10 @@ contains
 
     implicit none
     type(atmos_data_type), intent(inout) :: Atm !< Atm
-    integer,                   intent(in) :: current_timestep   !< Current timestep 
+    integer,                   intent(in) :: current_timestep   !< Current timestep
     type(coupler_chksum_type), intent(in) :: coupler_chksum_obj !< coupler_chksum_obj pointing to component types
     type(coupler_clock_type),  intent(inout) :: coupler_clocks  !< coupler_clocks
-    
+
     call fms_mpp_clock_begin(coupler_clocks%update_atmos_model_dynamics)
     call update_atmos_model_dynamics(Atm)
     call fms_mpp_clock_end(coupler_clocks%update_atmos_model_dynamics)
@@ -1976,7 +1976,7 @@ contains
         coupler_chksum_obj%Atmos_ice_boundary, coupler_chksum_obj%Atmos_land_boundary)
 
     if (do_debug)  call fms_memutils_print_memuse_stats( 'update dyn')
-    
+
   end subroutine coupler_update_atmos_model_dynamics
 
   !> This subroutine calls update_atmos_model_radiation.  Clocks are set for runtime statistics.
@@ -1990,11 +1990,11 @@ contains
     type(atmos_data_type), intent(inout) :: Atm
     type(land_ice_atmos_boundary_type), intent(inout) :: Land_ice_atmos_boundary
     type(coupler_clock_type),         intent(inout) :: coupler_clocks     !< coupler_clocks
-    integer,                   optional, intent(in) :: current_timestep   !< Current timestep 
+    integer,                   optional, intent(in) :: current_timestep   !< Current timestep
     type(coupler_chksum_type), optional, intent(in) :: coupler_chksum_obj !< points to component types
 
     character(128) :: memuse_stats_id = 'update serial rad'
-    
+
     call fms_mpp_clock_begin(coupler_clocks%radiation)
     call update_atmos_model_radiation( Land_ice_atmos_boundary, Atm )
     call fms_mpp_clock_end(coupler_clocks%radiation)
@@ -2006,7 +2006,7 @@ contains
                                        Atm, coupler_chksum_obj%Land, coupler_chksum_obj%Ice, Land_ice_atmos_boundary,  &
                                        coupler_chksum_obj%Atmos_ice_boundary, coupler_chksum_obj%Atmos_land_boundary)
     end if
-    
+
     if (do_debug) then
       if(do_concurrent_radiation) memuse_stats_id = 'update concurrent rad'
       call fms_memutils_print_memuse_stats(trim(memuse_stats_id))
@@ -2022,7 +2022,7 @@ contains
     implicit none
     type(atmos_data_type), intent(inout) :: Atm  !< Atm
     type(land_ice_atmos_boundary_type), intent(inout) :: Land_ice_atmos_boundary !<Land ice_atmos_boundary
-    integer,                   intent(in) :: current_timestep   !< Current timestep 
+    integer,                   intent(in) :: current_timestep   !< Current timestep
     type(coupler_chksum_type), intent(in) :: coupler_chksum_obj !< coupler_chksum_obj pointing to component types
     type(coupler_clock_type),  intent(inout) :: coupler_clocks  !< coupler_clocks
 
@@ -2053,7 +2053,7 @@ contains
     type(FmsTime_type), intent(in) :: Time_atmos       !<Time_atmos FmsTime_type containing time in seconds
     integer,            intent(in) :: current_timestep !< current_timestep
     type(coupler_clock_type), intent(inout) :: coupler_clocks !<coupler_clocks
-    
+
     call fms_mpp_clock_begin(coupler_clocks%flux_down_from_atmos)
     call flux_down_from_atmos(Time_atmos, Atm, Land, Ice, Land_ice_atmos_boundary, &
                               Atmos_land_boundary, Atmos_ice_boundary )
@@ -2061,7 +2061,7 @@ contains
 
     if (do_chksum) call atmos_ice_land_chksum('flux_down_from_atmos+', current_timestep, Atm, Land, &
                    Ice, Land_ice_atmos_boundary, Atmos_ice_boundary, Atmos_land_boundary)
-          
+
   end subroutine coupler_flux_down_from_atmos
-  
+
 end module full_coupler_mod

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -1262,8 +1262,6 @@ contains
     type(coupler_clock_type), intent(in) :: coupler_clocks
     type(coupler_chksum_type), intent(in) :: coupler_chksum_obj
 
-    type(coupler_chksum_type), intent(in) :: coupler_chksum_obj
-
     type(FmsTime_type), intent(in) :: Time, Time_start, Time_end, Time_restart_current
     integer :: num_ice_bc_restart, num_ocn_bc_restart
 

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -331,8 +331,8 @@ contains
     integer, allocatable, dimension(:,:), intent(inout) :: ensemble_pelist
     integer, allocatable, dimension(:),   intent(inout) :: slow_ice_ocean_pelist
 
-    type(coupler_clock_type) :: coupler_clocks
-    type(coupler_chksum_type) :: coupler_chksum_obj
+    type(coupler_clock_type), intent(inout)  :: coupler_clocks
+    type(coupler_chksum_type), intent(inout) :: coupler_chksum_obj
 
     type(FMSTime_type), intent(inout) :: Time_step_cpld, Time_step_atmos, Time_atmos, Time_ocean
     type(FMSTime_type), intent(inout) :: Time, Time_start, Time_end, Time_restart, Time_restart_current

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -110,6 +110,7 @@ module full_coupler_mod
   public :: ocean_public_type_chksum, ice_ocn_bnd_type_chksum
 
   public :: coupler_init, coupler_end, coupler_restart, coupler_intermediate_restart
+  public :: coupler_summarize_timestep
 
   public :: coupler_flux_check_stocks
   public :: coupler_flux_ocean_to_ice 

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -2067,11 +2067,13 @@ contains
 
   !> This subroutine calls update_land_model_fast.  Clocks are set for runtime statistics.  Chksums
   !! and memory usage are computed if do_chksum and do_debug are .True.
-  subroutine coupler_update_land_model_fast(Land, Atmos_land_boundary, current_timestep, coupler_chksum_obj, coupler_clocks)
+  subroutine coupler_update_land_model_fast(Land, Atmos_land_boundary, atm_pelist, current_timestep, &
+                                            coupler_chksum_obj, coupler_clocks)
 
     implicit none
-    type(land_data_type),      intent(inout) :: Land                !< Land
-    type(atmos_land_boundary), intent(inout) :: Atmos_land_boundary !< Atmos_land_boundary
+    type(land_data_type),           intent(inout) :: Land !< Land
+    type(atmos_land_boundary_type), intent(inout) :: Atmos_land_boundary !< Atmos_land_boundary
+    integer, dimension(:), intent(in) :: atm_pelist !< Atm%pelist to reset the pelist to Atm%pelist
     integer,                   intent(in) :: current_timestep       !< current timestep
     type(coupler_chksum_type), intent(in) :: coupler_chksum_obj     !< points to component types
     type(coupler_clock_type),  intent(inout) :: coupler_clocks      !< coupler_clocks
@@ -2081,7 +2083,7 @@ contains
     
     call update_land_model_fast( Atmos_land_boundary, Land )
 
-    if (land_npes .NE. atmos_npes) call fms_mpp_set_current_pelist(Atm%pelist)
+    if (land_npes .NE. atmos_npes) call fms_mpp_set_current_pelist(atm_pelist)
     call fms_mpp_clock_end(coupler_clocks%update_land_model_fast)
     
     if (do_chksum) call atmos_ice_land_chksum('update_land_fast+', current_timestep, coupler_chksum_obj%Atm, Land, &
@@ -2093,11 +2095,13 @@ contains
 
   !> This subroutine calls update_ice_model_fast.  Clocks are set for runtime statistics.  Chksums
   !! and memory usage are computed if do_chksum and do_debug are .True.
-  subroutine coupler_update_ice_model_fast(Ice, Atmos_ice_boundary, current_timestep, coupler_chksum_obj, coupler_clocks)
+  subroutine coupler_update_ice_model_fast(Ice, Atmos_ice_boundary, atm_pelist, current_timestep, &
+                                           coupler_chksum_obj, coupler_clocks)
 
     implicit none
-    type(ice_data_type),      intent(inout) :: Ice                !< Ice
-    type(Atmos_ice_boundary), intent(inout) :: Atmos_ice_boundary !< Atmos_ice_boundary
+    type(ice_data_type),           intent(inout) :: Ice                !< Ice
+    type(Atmos_ice_boundary_type), intent(inout) :: Atmos_ice_boundary !< Atmos_ice_boundary
+    integer, dimension(:), intent(in) :: atm_pelist !< Atm%pelist to reset the pelist to Atm%pelist
     integer,                     intent(in) :: current_timestep   !< current_timestep
     type(coupler_chksum_type),   intent(in) :: coupler_chksum_obj !< points to component types
     type(coupler_clock_type), intent(inout) :: coupler_clocks     !< coupler_clocks
@@ -2107,7 +2111,7 @@ contains
 
     call update_ice_model_fast( Atmos_ice_boundary, Ice )
     
-    if (ice_npes .NE. atmos_npes) call fms_mpp_set_current_pelist(Atm%pelist)
+    if (ice_npes .NE. atmos_npes) call fms_mpp_set_current_pelist(atm_pelist)
     call fms_mpp_clock_end(coupler_clocks%update_ice_model_fast)
 
     if (do_chksum) call atmos_ice_land_chksum('update_ice_fast+', current_timestep, coupler_chksum_obj%Atm,&
@@ -2148,8 +2152,8 @@ contains
                                            coupler_chksum_obj, coupler_clocks)
 
     implicit none
-    type(atmos_data_type),         intent(inout) :: Atm                     !< Atm
-    type(land_ice_atmos_boundary), intent(inout) :: Land_ice_atmos_boundary  !< Land_ice_atmos_boundary
+    type(atmos_data_type),              intent(inout) :: Atm                      !< Atm
+    type(land_ice_atmos_boundary_type), intent(inout) :: Land_ice_atmos_boundary  !< Land_ice_atmos_boundary
     integer,                  intent(in) :: current_timestep   !< current_timestep
     type(coupler_chksum_type),intent(in) :: coupler_chksum_obj !< points to component types
     type(coupler_clock_type), intent(inout) :: coupler_clocks  !< coupler_clocks

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -297,7 +297,7 @@ module full_coupler_mod
   !! The members of this type point to the model components
   type coupler_chksum_type
     private
-    type(coupler_components_type), pointer :: components
+    type(coupler_components_type) :: components
   contains
     procedure, public :: initialize_coupler_chksum_obj !< associates the pointers above to model components
     procedure, public :: get_components_obj !< subroutine to retrieve the requested component of an object of this type

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -1544,7 +1544,7 @@ contains
 
     call fms_mpp_set_current_pelist()
 
-  end subroutine get_coupler_atmos_ice_land_ocean_chksums
+  end subroutine get_atmos_ice_land_ocean_chksums
   
 !> \brief This subroutine calls subroutine that will print out checksums of the elements
 !! of the appropriate type.

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -1139,9 +1139,6 @@ contains
     end if
 
     call fms_mpp_set_current_pelist()
-    call flux_init_stocks(Time, Atm, Land, Ice, Ocean_state)
-
-    call fms_mpp_set_current_pelist()
     call fms_memutils_print_memuse_stats('coupler_init')
 
     if (fms_mpp_pe().EQ.fms_mpp_root_pe()) then

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -1272,6 +1272,8 @@ contains
     type(FmsTime_type), intent(in) :: Time, Time_start, Time_end
     integer :: num_ice_bc_restart, num_ocn_bc_restart
 
+    call fms_mpp_clock_begin(coupler_clocks%termination)
+    
     if (do_chksum) call coupler_chksum_obj%get_coupler_chksums('coupler_end-', current_timestep)   
     if ( do_endpoint_chksum ) then
       call coupler_chksum_obj%get_atmos_ice_land_ocean_chksums('coupler_end', 0)
@@ -1328,8 +1330,9 @@ contains
 #ifdef use_deprecated_io
     call fms_io_exit
 #endif
-    call fms_mpp_set_current_pelist()
 
+    call fms_mpp_set_current_pelist()
+    call fms_mpp_clock_end(coupler_clocks%termination)
 
 !-----------------------------------------------------------------------
 

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -1147,6 +1147,7 @@ contains
       write(errunit,*) 'Exiting coupler_init at '&
                        //trim(walldate)//' '//trim(walltime)
     endif
+    
   end subroutine coupler_init
 
 !#######################################################################
@@ -1318,14 +1319,6 @@ contains
     !----- write restart file ------
     call coupler_restart(Atm, Ice, Ocean, Ocn_bc_restart, Ice_bc_restart, &
                          Time, Time_start)
-    
-    call fms_mpp_set_current_pelist()
-    call fms_mpp_clock_begin(coupler_clocks%final_flux_check_stocks)
-    if (check_stocks >= 0) then
-      call fms_mpp_set_current_pelist()
-      call flux_check_stocks(Time=Time, Atm=Atm, Lnd=Land, Ice=Ice, Ocn_state=Ocean_state)
-    endif
-    call fms_mpp_clock_end(coupler_clocks%final_flux_check_stocks)
     
     call fms_diag_end (Time)
 #ifdef use_deprecated_io

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -1361,6 +1361,7 @@ contains
     character(len=*), intent(in),  optional :: time_stamp !< time_stamp for restart
 
     character(len=128) :: file_run, file_res
+
     integer :: yr, mon, day, hr, min, sec, date(6), n
     integer ::  num_ice_bc_restart, num_ocn_bc_restart
     integer :: restart_unit !< Unit for the coupler restart file

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -1353,11 +1353,9 @@ contains
 
     type(FmsNetcdfDomainFile_t), dimension(:), pointer, intent(inout) :: Ocn_bc_restart !< required for restarts
     type(FmsNetcdfDomainFile_t), dimension(:), pointer, intent(inout) :: Ice_bc_restart !< required for restarts
-
-    !> Restart files will be written when Time=>Time_restart.  Time_restart is incremented by restart_interval
-    !! Time_restart_current records the current timestep the restart file is being written.
-    !! Time_restart_current does not necessary = Time_restart.    
-    type(FmsTime_type),  intent(in)  :: Time_current, Time_restart_current, Time_start
+    type(FmsTime_type), intent(in) :: Time_current         !< current model runtime (Time)
+    type(FmsTime_type), intent(in) :: Time_restart_current !< current restart time
+    type(FmsTime_type), intent(in) :: Time_start           !< model start time
     character(len=*), intent(in),  optional :: time_stamp !< time_stamp for restart
 
     character(len=128) :: file_run, file_res

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -1889,10 +1889,10 @@ contains
     type(atmos_data_type), intent(inout) :: Atm  !< Atm
     type(land_data_type), intent(inout)  :: Land !< Land
     type(ice_data_type), intent(inout)   :: Ice  !< Ice
-    type(land_ice_atmos_boundary_type), intent(inout) :: Land_ice_atmos_boundary
-    type(atmos_ice_boundary_type), intent(inout) :: Atmos_ice_boundary  !<Required for chksum
-    type(atmo_land_boundary), intent(inout)      :: Atmos_land_boundary !<Required for chksum
-    type(FmsTimeType), intent(in) :: Time_atmos            !< Atmos time
+    type(land_ice_atmos_boundary_type), intent(inout) :: Land_ice_atmos_boundary !< Land_ice_atmos_boundary
+    type(atmos_ice_boundary_type), intent(inout)  :: Atmos_ice_boundary  !<Required for chksum
+    type(atmos_land_boundary_type), intent(inout) :: Atmos_land_boundary !<Required for chksum
+    type(FmsTime_type), intent(in) :: Time_atmos           !< Atmos time
     integer, intent(in)           :: current_time_step     !< (nc-1)*num_atmos_cal + na
     type(coupler_clock_type), intent(in) :: coupler_clocks !< coupler_clocks
                                                                                 

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -289,7 +289,6 @@ module full_coupler_mod
   contains
     procedure, public :: initialize_coupler_components_obj
     procedure, public :: get_component  !< subroutine to retrieve the requested component of an object of this type
-    procedure, public :: set_component  !< subroutine to set requested component of an object of this type
   end type coupler_components_type
 
   !> The purpose of objects of coupler_chksum_type is to simplify the list
@@ -297,11 +296,10 @@ module full_coupler_mod
   !! The members of this type point to the model components
   type coupler_chksum_type
     private
-    type(coupler_components_type) :: components
+    type(coupler_components_type), pointer :: components
   contains
     procedure, public :: initialize_coupler_chksum_obj !< associates the pointers above to model components
     procedure, public :: get_components_obj !< subroutine to retrieve the requested component of an object of this type
-    procedure, public :: set_components_obj !< subroutine to set components object
     procedure, public :: get_atmos_ice_land_ocean_chksums !< subroutine to compute chksums for atmos - ocean
     procedure, public :: get_atmos_ice_land_chksums !< subroutine to compute chksums for atmos_ice_land
     procedure, public :: get_slow_ice_chksums       !< subroutine to compute chskums for slow_ice
@@ -1214,45 +1212,14 @@ contains
 
   end subroutine get_component
 
-  !> Function set_component sets the requested component in the coupler_components_type object
-  !! Users are required to provide the component to be set as an input argument.  For example,
-  !! coupler_components_obj%get_component(Atm) will set coupler_components_obj%Atm = Atm
-  subroutine set_component(this, set_this_component )
-
-    implicit none
-    class(coupler_components_type), intent(inout) :: this !< the coupler_components_type object
-    class(*), intent(in) :: set_this_component  !< requested component to be be set.
-                            !! set_this_component can be of type atmos_data_type, land_data_type, ice_data_type,
-                            !! ocean_public_type, land_ice_atmos_boundary_type, atmos_land_boundary_type,
-                            !! atmos_ice_boundary_type, land_ice_boundary_type, ice_ocean_boundary_type,
-                            !! ocean_ice_boundary_type
-
-    select type(set_this_component)
-    type is(atmos_data_type)   ; this%Atm  = set_this_component
-    type is(land_data_type)    ; this%Land = set_this_component
-    type is(ice_data_type)     ; this%Ice  = set_this_component
-    type is(ocean_public_type) ; this%Ocean = set_this_component
-    type is(land_ice_atmos_boundary_type) ; this%Land_ice_atmos_boundary = set_this_component
-    type is(atmos_land_boundary_type) ; this%Atmos_land_boundary = set_this_component
-    type is(atmos_ice_boundary_type)  ; this%Atmos_ice_boundary = set_this_component
-    type is(land_ice_boundary_type)   ; this%Land_ice_boundary  = set_this_component
-    type is(ice_ocean_boundary_type)  ; this%Ice_ocean_boundary = set_this_component
-    type is(ocean_ice_boundary_type)  ; this%Ocean_ice_boundary = set_this_component
-    class default
-      call fms_mpp_error(FATAL, "failure setting component in coupler_components_type object, &
-                         cannot recognize the type of requested component")
-    end select
-
-  end subroutine set_component
-
   !> This subroutine associates the pointer in an object of coupler_chksum_type to the component models
   subroutine initialize_coupler_chksum_obj(this, components_obj)
 
     implicit none
     class(coupler_chksum_type), intent(inout) :: this
-    type(coupler_components_type), intent(in) :: components_obj
+    type(coupler_components_type), intent(in), target :: components_obj
 
-    this%components = components_obj
+    this%components => components_obj
 
   end subroutine initialize_coupler_chksum_obj
 
@@ -1267,18 +1234,6 @@ contains
     components_obj = this%components
 
   end subroutine get_components_obj
-
-  !> This subroutine set coupler_chksum_obj%components_obj
-  subroutine set_components_obj(this, components_obj)
-
-    implicit none
-
-    class(coupler_chksum_type), intent(inout) :: this  !< coupler_chksum_type
-    type(coupler_components_type), intent(in) :: components_obj !< coupler_components_type to be used
-
-    this%components = components_obj
-
-  end subroutine set_components_obj
 
   !> This subroutine finalizes the run
   subroutine coupler_end(Atm, Land, Ice, Ocean, Ocean_state, Land_ice_atmos_boundary, Atmos_ice_boundary,&

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -297,7 +297,7 @@ module full_coupler_mod
   !! The members of this type point to the model components
   type coupler_chksum_type
     private
-    type(coupler_components_type) :: components
+    type(coupler_components_type), pointer :: components
   contains
     procedure, public :: initialize_coupler_chksum_obj !< associates the pointers above to model components
     procedure, public :: get_components_obj !< subroutine to retrieve the requested component of an object of this type
@@ -1252,9 +1252,9 @@ contains
 
     implicit none
     class(coupler_chksum_type), intent(inout) :: this
-    type(coupler_components_type), intent(in) :: components_obj
+    type(coupler_components_type), target, intent(in) :: components_obj
 
-    this%components = components_obj
+    this%components => components_obj
 
   end subroutine initialize_coupler_chksum_obj
 

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -276,7 +276,7 @@ module full_coupler_mod
 
   type coupler_components_type
     private
-    type(atmos_data_type), pointer :: Atm  !< pointer to Atm 
+    type(atmos_data_type), pointer :: Atm  !< pointer to Atm
     type(land_data_type),  pointer :: Land !< pointer to Land
     type(ice_data_type),   pointer :: Ice  !< pointer to Ice
     type(ocean_public_type), pointer :: Ocean  !< pointer to Ocean
@@ -289,17 +289,19 @@ module full_coupler_mod
   contains
     procedure, public :: coupler_components_obj_init
     procedure, public :: get_component  !< subroutine to retrieve the requested component of an object of this type
-  end type coupler_components_type  
-  
+    procedure, public :: set_component  !< subroutine to set requested component of an object of this type
+  end type coupler_components_type
+
   !> The purpose of objects of coupler_chksum_type is to simplify the list
   !! of arguments required for chksum related subroutines in full_coupler_mod.
-  !! The members of this type point to the model components 
+  !! The members of this type point to the model components
   type coupler_chksum_type
     private
     type(coupler_components_type), pointer :: components
   contains
     procedure, public :: coupler_chksum_obj_init !< associates the pointers above to model components
     procedure, public :: get_components_obj !< subroutine to retrieve the requested component of an object of this type
+    procedure, public :: set_components_obj !< subroutine to set components object
     procedure, public :: get_atmos_ice_land_ocean_chksums !< subroutine to compute chksums for atmos - ocean
     procedure, public :: get_atmos_ice_land_chksums !< subroutine to compute chksums for atmos_ice_land
     procedure, public :: get_slow_ice_chksums       !< subroutine to compute chskums for slow_ice
@@ -1127,7 +1129,7 @@ contains
     !> Initialize coupler_components_obj memebers to point to model components
     call coupler_components_obj%coupler_components_obj_init(Atm, Land, Ice, Ocean, Land_ice_atmos_boundary, &
         Atmos_land_boundary, Atmos_ice_boundary, Land_ice_boundary, Ice_ocean_boundary, Ocean_ice_boundary)
-    
+
     !> Initialize coupler_chksum_obj
     call coupler_chksum_obj%coupler_chksum_obj_init(coupler_components_obj)
 
@@ -1187,7 +1189,7 @@ contains
   subroutine get_component(this, retrieve_component )
 
     implicit none
-    class(coupler_components_type), intent(in) :: this !< the coupler_components_type object 
+    class(coupler_components_type), intent(in) :: this !< the coupler_components_type object
     class(*), intent(out) :: retrieve_component  !< requested component to be retrieve.
                              !! retrieve_component can be of type atmos_data_type, land_data_type, ice_data_type,
                              !! ocean_public_type, land_ice_atmos_boundary_type, atmos_land_boundary_type,
@@ -1195,7 +1197,7 @@ contains
                              !! ocean_ice_boundary_type
 
     select type(retrieve_component)
-    type is(atmos_data_type) ; retrieve_component = this%Atm 
+    type is(atmos_data_type) ; retrieve_component = this%Atm
     type is(land_data_type)  ; retrieve_component = this%Land
     type is(ice_data_type)   ; retrieve_component = this%Ice
     type is(ocean_public_type) ; retrieve_component = this%Ocean
@@ -1209,10 +1211,41 @@ contains
       call fms_mpp_error(FATAL, "failure retrieving component in coupler_components_type object, &
                          cannot recognize the type of requested component")
     end select
-      
+
   end subroutine get_component
-    
-  !> This subroutine associates the pointer in an object of coupler_chksum_type to the component models 
+
+  !> Function set_component sets the requested component in the coupler_components_type object
+  !! Users are required to provide the component to be set as an input argument.  For example,
+  !! coupler_components_obj%get_component(Atm) will set coupler_components_obj%Atm = Atm
+  subroutine set_component(this, set_this_component )
+
+    implicit none
+    class(coupler_components_type), intent(inout) :: this !< the coupler_components_type object
+    class(*), intent(in) :: set_this_component  !< requested component to be be set.
+                            !! set_this_component can be of type atmos_data_type, land_data_type, ice_data_type,
+                            !! ocean_public_type, land_ice_atmos_boundary_type, atmos_land_boundary_type,
+                            !! atmos_ice_boundary_type, land_ice_boundary_type, ice_ocean_boundary_type,
+                            !! ocean_ice_boundary_type
+
+    select type(set_this_component)
+    type is(atmos_data_type)   ; this%Atm  = set_this_component
+    type is(land_data_type)    ; this%Land = set_this_component
+    type is(ice_data_type)     ; this%Ice  = set_this_component
+    type is(ocean_public_type) ; this%Ocean = set_this_component
+    type is(land_ice_atmos_boundary_type) ; this%Land_ice_atmos_boundary = set_this_component
+    type is(atmos_land_boundary_type) ; this%Atmos_land_boundary = set_this_component
+    type is(atmos_ice_boundary_type)  ; this%Atmos_ice_boundary = set_this_component
+    type is(land_ice_boundary_type)   ; this%Land_ice_boundary  = set_this_component
+    type is(ice_ocean_boundary_type)  ; this%Ice_ocean_boundary = set_this_component
+    type is(ocean_ice_boundary_type)  ; this%Ocean_ice_boundary = set_this_component
+    class default
+      call fms_mpp_error(FATAL, "failure setting component in coupler_components_type object, &
+                         cannot recognize the type of requested component")
+    end select
+
+  end subroutine set_component
+
+  !> This subroutine associates the pointer in an object of coupler_chksum_type to the component models
   subroutine coupler_chksum_obj_init(this, components_obj)
 
     implicit none
@@ -1220,20 +1253,32 @@ contains
     type(coupler_components_type), intent(in) :: components_obj
 
     this%components = components_obj
-    
+
   end subroutine coupler_chksum_obj_init
 
   !> This subroutine retrieves coupler_chksum_obj%components_obj
   subroutine get_components_obj(this, components_obj)
 
     implicit none
-    
+
     class(coupler_chksum_type), intent(in)     :: this  !< coupler_chksum_type
     type(coupler_components_type), intent(out) :: components_obj !< coupler_components_type to be returned
 
     components_obj = this%components
-    
+
   end subroutine get_components_obj
+
+  !> This subroutine set coupler_chksum_obj%components_obj
+  subroutine set_components_obj(this, components_obj)
+
+    implicit none
+
+    class(coupler_chksum_type), intent(inout) :: this  !< coupler_chksum_type
+    type(coupler_components_type), intent(in) :: components_obj !< coupler_components_type to be used
+
+    this%components = components_obj
+
+  end subroutine set_components_obj
 
   !> This subroutine finalizes the run
   subroutine coupler_end(Atm, Land, Ice, Ocean, Ocean_state, Land_ice_atmos_boundary, Atmos_ice_boundary,&
@@ -1256,7 +1301,7 @@ contains
     type(FmsNetcdfDomainFile_t), dimension(:), pointer, intent(inout) :: Ice_bc_restart
 
     type(coupler_chksum_type), intent(in) :: coupler_chksum_obj
-    
+
     type(FmsTime_type), intent(in) :: Time, Time_start, Time_end, Time_restart_current
     integer :: num_ice_bc_restart, num_ocn_bc_restart
 
@@ -1428,7 +1473,7 @@ contains
   subroutine get_coupler_chksums(this, id, timestep)
 
     implicit none
-    
+
     class(coupler_chksum_type), intent(in) :: this !< self
     character(len=*), intent(in) :: id        !< id to label CHECKSUMS in stdout
     integer         , intent(in) :: timestep  !< timestep
@@ -1532,7 +1577,7 @@ contains
     class(coupler_chksum_type), intent(in) :: this !< self
     character(len=*), intent(in) :: id       !< ID labelling the set of checksums
     integer         , intent(in) :: timestep !< timestep
-    
+
     if (this%components%Atm%pe) then
       call fms_mpp_set_current_pelist(this%components%Atm%pelist)
       call this%get_atmos_ice_land_chksums(trim(id), timestep)
@@ -1545,7 +1590,7 @@ contains
     call fms_mpp_set_current_pelist()
 
   end subroutine get_atmos_ice_land_ocean_chksums
-  
+
 !> \brief This subroutine calls subroutine that will print out checksums of the elements
 !! of the appropriate type.
 !! For coupled models typically these types are not defined on all processors.
@@ -1920,7 +1965,7 @@ contains
   !> \brief This subroutine calls exchange_fast_to_slow_ice.  Clocks are set before and after the call.
   !! The current pelist is set if the optional argument set_ice_current_pelist is set to true.
   subroutine coupler_exchange_fast_to_slow_ice(Ice, coupler_clocks, set_ice_current_pelist)
-    
+
     implicit none
     type(ice_data_type), intent(inout) :: Ice                 !< Ice
     type(coupler_clock_type), intent(inout) :: coupler_clocks !< coupler_clocks

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -1131,8 +1131,6 @@ contains
     !> Initialize coupler_chksum_obj
     call coupler_chksum_obj%initialize_coupler_chksum_obj(coupler_components_obj)
 
-    do_chksum = .True.
-    
     if ( do_endpoint_chksum ) then
       call coupler_chksum_obj%get_atmos_ice_land_ocean_chksums('coupler_init+', 0)
       if (Ice%slow_ice_PE) then

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -1133,6 +1133,8 @@ contains
     !> Initialize coupler_chksum_obj
     call coupler_chksum_obj%initialize_coupler_chksum_obj(coupler_components_obj)
 
+    do_chksum = .True.
+    
     if ( do_endpoint_chksum ) then
       call coupler_chksum_obj%get_atmos_ice_land_ocean_chksums('coupler_init+', 0)
       if (Ice%slow_ice_PE) then

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -1113,7 +1113,6 @@ contains
                                                     Atmos_land_boundary,Atmos_ice_boundary, Land_ice_boundary, &
                                                     Ice_ocean_boundary, Ocean_ice_boundary)
 
-    do_endpoint_chksum = .False.
     if ( do_endpoint_chksum ) then
       call coupler_atmos_ice_land_ocean_chksum('coupler_init+', 0, Atm, Land, Ice, &
           Land_ice_atmos_boundary, Atmos_ice_boundary, Atmos_land_boundary, Ocean, Ice_ocean_boundary)
@@ -1950,9 +1949,9 @@ contains
     call fms_mpp_clock_begin(coupler_clocks%sfc_boundary_layer)
 
     call sfc_boundary_layer( real(dt_atmos), Time_atmos, Atm, Land, Ice, Land_ice_atmos_boundary )
-    call atmos_ice_land_chksum('sfc+', current_time_step, Atm, Land, Ice, &
-        Land_ice_atmos_boundary, coupler_chksum_obj%Atmos_ice_boundary,                   &
-        coupler_chksum_obj%Atmos_land_boundary)
+    if(do_chksum) call atmos_ice_land_chksum('sfc+', current_time_step, Atm, Land, Ice, &
+                  Land_ice_atmos_boundary, coupler_chksum_obj%Atmos_ice_boundary,       &
+                  coupler_chksum_obj%Atmos_land_boundary)
 
     call fms_mpp_clock_end(coupler_clocks%sfc_boundary_layer)
 


### PR DESCRIPTION
In this PR, the subroutine `coupler_intermediate_restart` and ` coupler_summarize_timestep` hve been defined and is used in coupler_main.  

AM4, CM4, SPEAR, and OM4 experiments pass.