### PR TITLE
refactored coupler CHECKSUM fixes to 2024.02-beta1

### DIFF
--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -698,7 +698,7 @@ program coupler_main
         call coupler_intermediate_restart(Atm, Ice, Ocean, Ocean_state, Ocn_bc_restart, Ice_bc_restart, &
                                           Time, Time_restart, Time_restart_current, Time_start)
 
-    call coupler_summarize_timestep(current_timestep, num_cpld_calls, coupler_chksum_obj, Atm%pe, omp_sec, imb_sec)
+    call coupler_summarize_timestep(nc, num_cpld_calls, coupler_chksum_obj, Atm%pe, omp_sec, imb_sec)
 
     omp_sec(:)=0.
     imb_sec(:)=0.

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -441,8 +441,7 @@ program coupler_main
 
   if (check_stocks >= 0) call coupler_flux_init_finish_stocks(Time, Atm, Land, Ice, Ocean_state, &
                                                               coupler_clocks, init_stocks=.True.)
-  do_chksum = .True.
-  
+
   !> ocean/slow-ice integration loop
   coupled_timestep_loop : do nc = 1, num_cpld_calls
 
@@ -685,11 +684,11 @@ program coupler_main
       ! This call is just for record keeping of stocks transfer and
       ! does not modify either Ocean or Ice_ocean_boundary
       call flux_ocean_from_ice_stocks(Ocean_state, Ocean, Ice_ocean_boundary)
-      
+
       call fms_diag_send_complete(Time_step_cpld)
       Time_ocean = Time_ocean +  Time_step_cpld
       Time = Time_ocean
-      
+
       call fms_mpp_clock_end(coupler_clocks%ocean)
     endif
 

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -468,7 +468,7 @@ program coupler_main
 
     if (do_chksum) then
       call coupler_chksum_obj%get_coupler_chksums('flux_ocn2ice+', nc)
-      call coupler_chksum_obj%get_atmos_ice_land_ocean_chksums('flux_ocn2ice+', nc)
+      call coupler_chksum_obj%get_atmos_ice_land_chksums('flux_ocn2ice+', nc)
     end if
 
     ! needs to sit here rather than at the end of the coupler loop.

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -468,7 +468,7 @@ program coupler_main
 
     if (do_chksum) then
       call coupler_chksum_obj%get_coupler_chksums('flux_ocn2ice+', nc)
-      call coupler_chksum_obj%get_atmos_ice_land_chksums('flux_ocn2ice+', nc)
+      call coupler_chksum_obj%get_atmos_ice_land_ocean_chksums('flux_ocn2ice+', nc)
     end if
 
     ! needs to sit here rather than at the end of the coupler loop.

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -441,7 +441,8 @@ program coupler_main
 
   if (check_stocks >= 0) call coupler_flux_init_finish_stocks(Time, Atm, Land, Ice, Ocean_state, &
                                                               coupler_clocks, init_stocks=.True.)
-
+  do_chksum = .True.
+  
   !> ocean/slow-ice integration loop
   coupled_timestep_loop : do nc = 1, num_cpld_calls
 

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -678,7 +678,7 @@ program coupler_main
         if (do_chksum) call coupler_chksum_obj%get_ocean_chksums('update_ocean_model-', nc)
         ! update_ocean_model since fluxes don't change here
         if (do_ocean) call coupler_update_ocean_model(Ocean, Ocean_state, Ice_ocean_boundary,&
-                      Time_ocean, Time_step_cpld, current_timestep, coupler_chksum_obj)
+                      Time_ocean, Time_step_cpld, nc, coupler_chksum_obj)
       end if
 
       ! Get stocks from "Ice_ocean_boundary" and add them to Ocean stocks.


### PR DESCRIPTION
This PR should contain the following fix to 2024.02-beta1:  fix to remove additional ocean-related  `checksums` computations for `flux_ocn2ice+`.  These checksums are not computed in the pre-refactored full coupler.

It should be noted additional ocean-related chksums are computed for `flux_ocn2ice` in the refactored PR that are not computed in the pre-refactorization.  It was chosen to call `atmos_ice_land_ocean_chksum` instead of `atmos_ice_land_chksum` because the former contains all the necessary setting of current pelist and thus simplifies the chksum calls in the refactored coupler_main.