### PR TITLE
FREDB_ID removal 

### DIFF
--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -379,40 +379,6 @@ program coupler_main
   integer :: conc_nthreads = 1
   real :: dsec, omp_sec(2)=0.0, imb_sec(2)=0.0
 
-  !> FREDB_ID related variables
-  INTEGER :: i, status, arg_count
-  CHARACTER(len=256) :: executable_name, arg, fredb_id
-
-#ifdef FREDB_ID
-#define xstr(s) str(s)
-#define str(s) #s
-  fredb_id = xstr(FREDB_ID)
-#else
-#warning "FREDB_ID not defined. Continuing as normal."
-  fredb_id = 'FREDB_ID was not defined (e.g. -DFREDB_ID=...) during preprocessing'
-#endif
-
-  arg_count = command_argument_count()
-  DO i=0, arg_count
-    CALL get_command_argument(i, arg, status=status)
-    if (status .ne. 0) then
-      write (error_unit,*) 'get_command_argument failed: status = ', status, ' arg = ', i
-      stop 1
-    end if
-
-    if (i .eq. 0) then
-      executable_name = arg
-    else if (arg == '--fredb_id') then
-      write (output_unit,*) TRIM(fredb_id)
-      stop
-    end if
-  END DO
-
-  if (arg_count .ge. 1) then
-    write (error_unit,*) 'Usage: '//TRIM(executable_name)//' [--fredb_id]'
-    stop 1
-  end if
-
   call fms_mpp_init()
 
   !>these clocks are on the global pelist

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -336,7 +336,6 @@ program coupler_main
   use FMS
   use full_coupler_mod
 
-  use iso_fortran_env
   implicit none
 
   !> model defined types.


### PR DESCRIPTION
In this PR,

unused `FREDB_ID`-related code has been removed.

In addition, the `use iso_fortran_env` statement has been removed.  The `iso_fortran_env` module is no longer in  use since `error_unit` and `output_unit` iso_fortran_env variables are deleted as part of FREDB_ID pruning. 

This PR is related to issue #108 