### PR TITLE
Bypass flux routines if do_flux=.F.

### DIFF
--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -461,7 +461,7 @@ program coupler_main
       !> begin atm_clock_1
       call fms_mpp_clock_begin(coupler_clocks%atm)
 
-      call coupler_generate_sfc_xgrid(Land, Ice, coupler_clocks)
+      if (do_flux) call coupler_generate_sfc_xgrid(Land, Ice, coupler_clocks)
       call send_ice_mask_sic(Time)
 
       !-----------------------------------------------------------------------

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -1047,7 +1047,7 @@ contains
     endif
 
     call fms_mpp_clock_begin(coupler_clocks%flux_exchange_init)
-    call flux_exchange_init ( Time, Atm, Land, Ice, Ocean, Ocean_state,&
+    if(do_flux) call flux_exchange_init ( Time, Atm, Land, Ice, Ocean, Ocean_state,&
              atmos_ice_boundary, land_ice_atmos_boundary, &
              land_ice_boundary, ice_ocean_boundary, ocean_ice_boundary, &
          do_ocean, slow_ice_ocean_pelist, dt_atmos=dt_atmos, dt_cpld=dt_cpld)


### PR DESCRIPTION
Complementary to https://github.com/NOAA-GFDL/FMScoupler/pull/134, add do_flux flag for routines `coupler_generate_sfc_xgrid` and `flux_exchange_init`. 
Since no fluxes are being shared between components, there is no need for these routines.
With an appropriate namelist setup, full coupler shield can run with no coupled mosaic files.