### PR TITLE
Calve icebergs from ice-shelf flux

### DIFF
--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -490,10 +490,11 @@ program coupler_main
       ! This call occurs all ice PEs.
       if (concurrent_ice) then
         call coupler_exchange_fast_to_slow_ice(Ice, coupler_clocks)
-        call fms_mpp_clock_begin(coupler_clocks%update_ice_model_slow_fast)
-        if (Ice%slow_ice_pe .and. calve_ice_shelf_bergs) &
+        if (Ice%slow_ice_pe .and. calve_ice_shelf_bergs) then
+          call fms_mpp_clock_begin(coupler_clocks%update_ice_model_slow_fast)
           call unpack_ocean_ice_boundary_calved_shelf_bergs(Ice, Ocean_ice_boundary)
-        call fms_mpp_clock_end(coupler_clocks%update_ice_model_slow_fast)
+          call fms_mpp_clock_end(coupler_clocks%update_ice_model_slow_fast)
+        endif
       endif
 
       ! call fms_mpp_set_current_pelist(Ice%pelist) is called if(.not.Ice%shared_slow_fast_PEs)
@@ -738,9 +739,11 @@ program coupler_main
       ! This could be a point where the model is serialized; This calls on all ice PEs
       if (.not.concurrent_ice) then
         call coupler_exchange_fast_to_slow_ice(Ice, coupler_clocks, set_ice_current_pelist=.True.)
-        if (Ice%slow_ice_pe .and. calve_ice_shelf_bergs) &
+        if (Ice%slow_ice_pe .and. calve_ice_shelf_bergs) then
+          call fms_mpp_clock_begin(coupler_clocks%update_ice_model_slow_fast)
           call unpack_ocean_ice_boundary_calved_shelf_bergs(Ice, Ocean_ice_boundary)
-        call fms_mpp_clock_end(coupler_clocks%update_ice_model_slow_fast)
+          call fms_mpp_clock_end(coupler_clocks%update_ice_model_slow_fast)
+        endif
       endif
 
       !   ------ slow-ice model ------

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -102,6 +102,7 @@ module full_coupler_mod
   public :: update_land_model_fast, update_land_model_slow
   public :: update_ice_model_fast, set_ice_surface_fields
   public :: unpack_ocean_ice_boundary, exchange_slow_to_fast_ice
+  public :: unpack_ocean_ice_boundary_calved_shelf_bergs
   public :: ice_model_fast_cleanup, unpack_land_ice_boundary
   public :: exchange_fast_to_slow_ice, update_ice_model_slow
   public :: update_ocean_model, update_slow_ice_and_ocean
@@ -219,7 +220,7 @@ module full_coupler_mod
   logical, public :: do_debug=.FALSE.!< If .TRUE. print additional debugging messages.
   integer, public :: check_stocks = 0 !< -1: never 0: at end of run only n>0: every n coupled steps
   logical, public :: use_hyper_thread = .false.
-  logical :: calve_ice_shelf_bergs = .false. !< If true, flux through a static ice front is converted
+  logical, public :: calve_ice_shelf_bergs = .false. !< If true, flux through a static ice front is converted
                                              !!to point bergs
 
   namelist /coupler_nml/ current_date, calendar, force_date_from_namelist,         &

--- a/full/ice_ocean_flux_exchange.F90
+++ b/full/ice_ocean_flux_exchange.F90
@@ -377,7 +377,7 @@ contains
   !!        v_surf = meridional ocean current/ice motion (m/s)
   !!        v_surf = meridional ocean current/ice motion (m/s)
   !!        sea_lev = sea level used to drive ice accelerations (m)
-  !!        calving = ice-sheet calving flux to ocean (kg m-2 s-1)
+  !!        calving = ice-sheet calving flux to ocean (kg/m2/s)
   !!        calving_hflx = heat flux associated with ice-sheet calving (W/m2)
   !! </pre>
   !!

--- a/full/ice_ocean_flux_exchange.F90
+++ b/full/ice_ocean_flux_exchange.F90
@@ -475,7 +475,8 @@ contains
                call divide_by_area(data=Ocean_Ice_Boundary%calving, area=Ice%area)
              if (Ocean%is_ocean_pe) deallocate(tmp)
           else
-             call fms_mpp_domains_redistribute(Ocean%Domain, Ocean%calving, Ice%slow_Domain_NH, Ocean_Ice_Boundary%calving)
+             call fms_mpp_domains_redistribute(Ocean%Domain, Ocean%calving, Ice%slow_Domain_NH, &
+                                               Ocean_Ice_Boundary%calving)
           endif
        endif
        if( ASSOCIATED(Ocean_Ice_Boundary%calving_hflx) ) then
@@ -489,7 +490,8 @@ contains
                call divide_by_area(data=Ocean_Ice_Boundary%calving_hflx, area=Ice%area)
              if (Ocean%is_ocean_pe) deallocate(tmp)
           else
-             call fms_mpp_domains_redistribute(Ocean%Domain, Ocean%calving_hflx, Ice%slow_Domain_NH, Ocean_Ice_Boundary%calving_hflx)
+             call fms_mpp_domains_redistribute(Ocean%Domain, Ocean%calving_hflx, Ice%slow_Domain_NH, &
+                                               Ocean_Ice_Boundary%calving_hflx)
           endif
        endif
 


### PR DESCRIPTION
This PR adds the capability to calve point-particle icebergs from ice shelves:

If `calve_ice_shelf_bergs=.true.` in the coupler namelist, then the mass and heat flux through the static ice-shelf front is accumulated at the coastal grid cells in `Ocean_Ice_Boundary%calving` and `Ocean_Ice_Boundary%calving_hflx`, respectively. 

Calling `unpack_ocean_ice_boundary_calved_shelf_bergs(Ice, Ocean_ice_boundary)` converts these fields to the SIS2 `FIA` type. These `FIA` fields are then passed to the icebergs module to initialize the iceberg particles.  This is analogous to the approach for initializing icebergs without an active ice-sheet component, where the coupler calls `unpack_land_ice_boundary(Ice, Land_ice_boundary)` to convert the frozen freshwater flux from river discharge into the required `FIA%calving` and `FIA%calving_hflx` fields.

See also https://github.com/NOAA-GFDL/MOM6/commit/b61022604a5ddde96be872cb6ec0d7ae9c58243b and https://github.com/NOAA-GFDL/SIS2/commit/2c49005d1d7132776fff9b501cabe6ae85ef5f57

