### PR TITLE
Small changes to ensure that valid surface temperature and moisture data are used for the coupled SHiELD

### DIFF
--- a/full/atm_land_ice_flux_exchange.F90
+++ b/full/atm_land_ice_flux_exchange.F90
@@ -1748,8 +1748,11 @@ contains
        !cjg          id_q_ref > 0 .or. id_q_ref_land >0 ) then
        do i = is,ie
           ex_ref(i) = 1.0e-06
-          if (ex_avail(i)) &
-               ex_ref(i)   = ex_tr_surf(i,isphum) + (ex_tr_atm(i,isphum)-ex_tr_surf(i,isphum)) * ex_del_q(i)
+          ! KGao fix for coupled SHiELD
+          if ( ex_avail(i) .and. ex_rough_moist(i) > 1e-9 ) & 
+                ex_ref(i) = ex_tr_surf(i,isphum) + (ex_tr_atm(i,isphum)-ex_tr_surf(i,isphum)) * ex_del_q(i) 
+          !if (ex_avail(i)) &
+          !     ex_ref(i)   = ex_tr_surf(i,isphum) + (ex_tr_atm(i,isphum)-ex_tr_surf(i,isphum)) * ex_del_q(i)
        enddo
     enddo
     call fms_xgrid_get_from_xgrid (Land_Ice_Atmos_Boundary%q_ref, 'ATM', ex_ref,   xmap_sfc)  ! cjg
@@ -1772,7 +1775,7 @@ contains
 #endif
     endif
     !$OMP parallel do default(none) shared(my_nblocks,block_start,block_end,ex_t_ref,ex_avail, &
-    !$OMP                                  ex_t_ca,ex_t_atm,ex_p_surf,ex_qs_ref,ex_del_h,      &
+    !$OMP                                  ex_rough_heat,ex_t_ca,ex_t_atm,ex_p_surf,ex_qs_ref,ex_del_h,      &
     !$OMP                                  ex_ref,ex_qs_ref_cmip,ex_ref2 ) &
     !$OMP                          private(is,ie)
     do l = 1, my_nblocks
@@ -1780,8 +1783,20 @@ contains
        ie=block_end(l)
        do i = is,ie
           ex_t_ref(i) = 200.
-          if(ex_avail(i)) &
+          ! KGao fix for coupled SHiELD
+          !if ( ex_avail(i) ) then
+          !   if ( ex_rough_heat(i) < 1e-9) then
+          !      ex_t_ref(i) = ex_t_atm(i)
+          !   else
+          !      ex_t_ref(i) = ex_t_ca(i) + (ex_t_atm(i)-ex_t_ca(i)) * ex_del_h(i)
+          !   endif
+          !endif
+
+          if ( ex_avail(i) .and. ex_rough_heat(i) > 1e-9 ) &
                ex_t_ref(i) = ex_t_ca(i) + (ex_t_atm(i)-ex_t_ca(i)) * ex_del_h(i)
+
+          !if(ex_avail(i)) &
+          !     ex_t_ref(i) = ex_t_ca(i) + (ex_t_atm(i)-ex_t_ca(i)) * ex_del_h(i)
        enddo
        call fms_sat_vapor_pres_compute_qs (ex_t_ref(is:ie), ex_p_surf(is:ie), ex_qs_ref(is:ie), q = ex_ref(is:ie))
        call fms_sat_vapor_pres_compute_qs (ex_t_ref(is:ie), ex_p_surf(is:ie), ex_qs_ref_cmip(is:ie),  &

--- a/full/atm_land_ice_flux_exchange.F90
+++ b/full/atm_land_ice_flux_exchange.F90
@@ -1748,7 +1748,7 @@ contains
        !cjg          id_q_ref > 0 .or. id_q_ref_land >0 ) then
        do i = is,ie
           ex_ref(i) = 1.0e-06
-          ! KGao fix for coupled SHiELD
+          ! KGao fix: preventing the use of invalid ex_del_q
           if ( ex_avail(i) .and. ex_rough_moist(i) > 1e-9 ) & 
                 ex_ref(i) = ex_tr_surf(i,isphum) + (ex_tr_atm(i,isphum)-ex_tr_surf(i,isphum)) * ex_del_q(i) 
           !if (ex_avail(i)) &
@@ -1783,15 +1783,7 @@ contains
        ie=block_end(l)
        do i = is,ie
           ex_t_ref(i) = 200.
-          ! KGao fix for coupled SHiELD
-          !if ( ex_avail(i) ) then
-          !   if ( ex_rough_heat(i) < 1e-9) then
-          !      ex_t_ref(i) = ex_t_atm(i)
-          !   else
-          !      ex_t_ref(i) = ex_t_ca(i) + (ex_t_atm(i)-ex_t_ca(i)) * ex_del_h(i)
-          !   endif
-          !endif
-
+          ! KGao fix: preventing the use of invalid ex_del_h
           if ( ex_avail(i) .and. ex_rough_heat(i) > 1e-9 ) &
                ex_t_ref(i) = ex_t_ca(i) + (ex_t_atm(i)-ex_t_ca(i)) * ex_del_h(i)
 


### PR DESCRIPTION
The coupled SHiELD-MOM6 system does not yet include any Land model at the coupler level yet and therefore does not have valid data for all land points.

This change ensures that the model does not break due to invalid temperature and moisture data (due to the invalid values of ex_del_q and ex_del_h produced by non-neutral version of the Monin-Obukhov diagnosis) being fed into the `fms_sat_vapor_pres_compute_qs` procedure, which caused out-of-bounds issues.

A very small threshold value (1e-9) is used to for `ex_rough_moist` and `ex_rough_heat`, which should not affect GFDL coupled Climate Model applications. 

After this change, one can set `neutral` to .false. in `monin_obukhov_nml` for the coupled SHiELD-MOM6 system.