### PR TITLE
Update simple coupler to initialize generic_exchange module

### DIFF
--- a/simple/coupler_main.F90
+++ b/simple/coupler_main.F90
@@ -152,6 +152,7 @@ implicit none
    call fms_init
    call fmsconstants_init
    call fms_affinity_init
+   call fms_gex_init
 
    call coupler_init
    if (do_chksum) call coupler_chksum('coupler_init+', 0)


### PR DESCRIPTION
Just adds a init call so the simple coupler does not error out when the generic exchange module is used in components.