### PR TITLE
Fix crash in ocean-ice models that use  _USE_LEGACY_LAND_

### DIFF
--- a/full/atm_land_ice_flux_exchange.F90
+++ b/full/atm_land_ice_flux_exchange.F90
@@ -3891,6 +3891,10 @@ contains
             standard_name='specific_humidity', missing_value=-1.0 )
        allocate(id_tr_flux_land(n_exch_tr))
        allocate(id_tr_mol_flux_land(n_exch_tr))
+       allocate(id_tr_con_atm_land(n_exch_tr)); id_tr_con_atm_land(:)=-1
+       allocate(id_tr_con_ref_land(n_exch_tr)); id_tr_con_ref_land(:)=-1
+       allocate(id_tr_ref_land(n_exch_tr)); id_tr_ref_land(:)=-1
+
        do tr = 1, n_exch_tr
           call fms_tracer_manager_get_tracer_names( MODEL_ATMOS, tr_table(tr)%atm, name, longname, units )
           id_tr_flux_land(tr) = fms_diag_register_diag_field( 'flux_land', trim(name)//'_flux', Land_axes, Time, &


### PR DESCRIPTION
- models that use legacy land (like land_null) seg fault at line 1837  atm_land_ice_flux_exchange.F90 because arrays are not allocated under commit 16ec1e4 and they are being accessed:
```
forrtl: severe (174): SIGSEGV, segmentation fault occurred
Image              PC                Routine            Line        Source             
libpthread-2.31.s  00007F194DB5F910  Unknown               Unknown  Unknown
fms_MOM6_SIS2_com  000000000043BEF6  atm_land_ice_flux        1837  atm_land_ice_flux_exchange.F90
fms_MOM6_SIS2_com  000000000041791E  full_coupler_mod_        2006  full_coupler_mod.F90
fms_MOM6_SIS2_com  00000000004127DC  MAIN__                    481  coupler_main.F90
```
- This fix allocates them and sets them to -1