### PR TITLE
Cheat mode

### DIFF
--- a/full/cheat_mode_mod.F90
+++ b/full/cheat_mode_mod.F90
@@ -30,14 +30,15 @@
 
 module cheat_mode_mod
   use FMS
+  use platform_mod, only: FMS_PATH_LEN
   implicit none
   private
 
   public :: cheat_mode_tarball_exists, cheat_mode_tarball_path, cheat_mode_init, cheat_mode_invoke
 
   logical :: cheat_mode_tarball_exists !< Whether to extract (true) or generate (false) a tarball
-  character(:), allocatable :: cheat_mode_tarball_path !< Path to the tarball to be extracted or created
-  character(:), allocatable :: dir !< Directory containing the tarballs
+  character(FMS_PATH_LEN) :: cheat_mode_tarball_path !< Path to the tarball to be extracted or created
+  character(FMS_PATH_LEN) :: dir !< Directory containing the tarballs
 
   namelist /cheat_mode_nml/ dir
 
@@ -56,19 +57,26 @@ contains
     read (fms_mpp_input_nml_file, cheat_mode_nml, iostat=io_status)
     io_status = fms_check_nml_error(io_status, "cheat_mode_nml")
 
-    allocate (character(len(dir) + 22) :: cheat_mode_tarball_path)
     write (cheat_mode_tarball_path, '(A,"/",I0.4,I0.2,I0.2,"_",I0.4,I0.2,I0.2,".tar")') &
-          dir, year0, month0, day0, year1, month1, day1
-    inquire (file=cheat_mode_tarball_path, exist=cheat_mode_tarball_exists)
+          trim(dir), year0, month0, day0, year1, month1, day1
+    inquire (file=trim(cheat_mode_tarball_path), exist=cheat_mode_tarball_exists)
   end subroutine
 
   !> Invoke the tar command to either create or extract the tarball. This subroutine
   !! should only be called by the root PE.
   subroutine cheat_mode_invoke
+    integer :: exitstat
+
     if (cheat_mode_tarball_exists) then
-      call execute_command_line("tar -xf " // cheat_mode_tarball_path // " --touch --overwrite")
+      call execute_command_line("tar -xf " // trim(cheat_mode_tarball_path) // &
+                                " --touch --overwrite", exitstat=exitstat)
     else
-      call execute_command_line("tar -cf " // cheat_mode_tarball_path // " `find . -type f -newer input.nml | xargs`")
+      call execute_command_line("tar -cf " // trim(cheat_mode_tarball_path) // &
+                                " `find . -type f -newer input.nml | xargs`", exitstat=exitstat)
+    endif
+
+    if (exitstat.ne.0) then
+      call fms_error_mesg("cheat mode", "tar command failed", FATAL)
     endif
   end subroutine cheat_mode_invoke
 end module cheat_mode_mod

--- a/full/cheat_mode_mod.F90
+++ b/full/cheat_mode_mod.F90
@@ -1,0 +1,79 @@
+!***********************************************************************
+!*                             Apache License 2.0
+!*
+!* This file is part of the GFDL Flexible Modeling System (FMS) Coupler.
+!*
+!* Licensed under the Apache License, Version 2.0 (the "License");
+!* you may not use this file except in compliance with the License.
+!* You may obtain a copy of the License at
+!*
+!*     http://www.apache.org/licenses/LICENSE-2.0
+!*
+!* FMS Coupler is distributed in the hope that it will be useful, but
+!* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied;
+!* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+!* PARTICULAR PURPOSE. See the License for the specific language
+!* governing permissions and limitations under the License.
+!***********************************************************************
+
+!> @defgroup cheat_mode_mod cheat_mode_mod
+!> @ingroup cheat_mode_mod
+!> @brief Generate or extract a tarball containing the final contents of a run directory.
+!!
+!> This module supports "cheat mode", so that the workflow can be tested without the
+!! computational cost of an actual model run. A directory is supplied via the
+!! `cheat_mode_nml` namelist: if a tarball is found in this directory corresponding
+!! to the date range of the current segment, `cheat_mode_invoke` will extract this
+!! tarball; otherwise, it will generate it from the content of the run directory.
+
+#ifdef CHEAT_MODE
+
+module cheat_mode_mod
+  use FMS
+  implicit none
+  private
+
+  public :: cheat_mode_tarball_exists, cheat_mode_tarball_path, cheat_mode_init, cheat_mode_invoke
+
+  logical :: cheat_mode_tarball_exists !< Whether to extract (true) or generate (false) a tarball
+  character(:), allocatable :: cheat_mode_tarball_path !< Path to the tarball to be extracted or created
+  character(:), allocatable :: dir !< Directory containing the tarballs
+
+  namelist /cheat_mode_nml/ dir
+
+!> @addtogroup cheat_mode_mod
+!> @{
+
+contains
+
+  !> Initialize cheat mode. Determine the path to the tarball from `cheat_mode_nml` and
+  !! from the date range of the current segment.
+  subroutine cheat_mode_init(year0, month0, day0, year1, month1, day1)
+    integer, intent(in) :: year0, month0, day0 !< Initial year, month, and day of the current segment
+    integer, intent(in) :: year1, month1, day1 !< Final year, month, and day of the current segment
+    integer :: io_status, ierr
+
+    read (input_nml_file, cheat_mode_nml, iostat=io_status)
+    ierr = check_nml_error(io_status, "cheat_mode_nml")
+
+    allocate (character(len(dir) + 22) :: cheat_mode_tarball_path)
+    write (cheat_mode_tarball_path, '(A,"/",I0.4,I0.2,I0.2,"_",I0.4,I0.2,I0.2,".tar")') &
+          dir, year0, month0, day0, year1, month1, day1
+    inquire (file=cheat_mode_tarball_path, exist=cheat_mode_tarball_exists)
+  end subroutine
+
+  !> Invoke the tar command to either create or extract the tarball. This subroutine
+  !! should only be called by the root PE.
+  subroutine cheat_mode_invoke
+    if (cheat_mode_tarball_exists) then
+      call execute_command_line("tar -xf " // cheat_mode_tarball_path // " --touch --overwrite")
+    else
+      call execute_command_line("tar -cf " // cheat_mode_tarball_path // " `find . -type f -newer input.nml | xargs`")
+    endif
+  end subroutine cheat_mode_invoke
+end module cheat_mode_mod
+
+#endif
+
+!> @}
+! close documentation grouping

--- a/full/cheat_mode_mod.F90
+++ b/full/cheat_mode_mod.F90
@@ -53,7 +53,7 @@ contains
     integer, intent(in) :: year1, month1, day1 !< Final year, month, and day of the current segment
     integer :: io_status
 
-    read (fms_input_nml_file, cheat_mode_nml, iostat=io_status)
+    read (fms_mpp_input_nml_file, cheat_mode_nml, iostat=io_status)
     io_status = fms_check_nml_error(io_status, "cheat_mode_nml")
 
     allocate (character(len(dir) + 22) :: cheat_mode_tarball_path)

--- a/full/cheat_mode_mod.F90
+++ b/full/cheat_mode_mod.F90
@@ -51,10 +51,10 @@ contains
   subroutine cheat_mode_init(year0, month0, day0, year1, month1, day1)
     integer, intent(in) :: year0, month0, day0 !< Initial year, month, and day of the current segment
     integer, intent(in) :: year1, month1, day1 !< Final year, month, and day of the current segment
-    integer :: io_status, ierr
+    integer :: io_status
 
-    read (input_nml_file, cheat_mode_nml, iostat=io_status)
-    ierr = check_nml_error(io_status, "cheat_mode_nml")
+    read (fms_input_nml_file, cheat_mode_nml, iostat=io_status)
+    io_status = fms_check_nml_error(io_status, "cheat_mode_nml")
 
     allocate (character(len(dir) + 22) :: cheat_mode_tarball_path)
     write (cheat_mode_tarball_path, '(A,"/",I0.4,I0.2,I0.2,"_",I0.4,I0.2,I0.2,".tar")') &

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -690,10 +690,8 @@ program coupler_main
 #ifdef CHEAT_MODE_DIR
   if (fms_mpp_pe().eq.fms_mpp_root_pe()) then
     if (cheatmode_on) then
-      call fms_error_mesg("cheat mode", "Extracting results tarball: " // cheatmode_file, NOTE)
       call execute_command_line("tar -xf " // cheatmode_file // " --touch --overwrite")
     else
-      call fms_error_mesg("cheat mode", "Generating results tarball: " // cheatmode_file, NOTE)
       call execute_command_line("tar -cf " // cheatmode_file // " `find . -type f -newer input.nml | xargs`")
     endif
   endif

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -687,4 +687,16 @@ program coupler_main
 
 !-----------------------------------------------------------------------
 
+#ifdef CHEAT_MODE_DIR
+  if (fms_mpp_pe().eq.fms_mpp_root_pe()) then
+    if (cheatmode_on) then
+      call error_mesg("cheat mode", "Extracting results tarball: " // cheatmode_file, NOTE)
+      call execute_command_line("tar -xf " // cheatmode_file // " --touch --overwrite")
+    else
+      call error_mesg("cheat mode", "Generating results tarball: " // cheatmode_file, NOTE)
+      call execute_command_line("tar -cf " // cheatmode_file // " `find . -type f -newer input.nml | xargs`")
+    endif
+  endif
+#endif
+
 end program coupler_main

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -690,10 +690,10 @@ program coupler_main
 #ifdef CHEAT_MODE_DIR
   if (fms_mpp_pe().eq.fms_mpp_root_pe()) then
     if (cheatmode_on) then
-      call error_mesg("cheat mode", "Extracting results tarball: " // cheatmode_file, NOTE)
+      call fms_error_mesg("cheat mode", "Extracting results tarball: " // cheatmode_file, NOTE)
       call execute_command_line("tar -xf " // cheatmode_file // " --touch --overwrite")
     else
-      call error_mesg("cheat mode", "Generating results tarball: " // cheatmode_file, NOTE)
+      call fms_error_mesg("cheat mode", "Generating results tarball: " // cheatmode_file, NOTE)
       call execute_command_line("tar -cf " // cheatmode_file // " `find . -type f -newer input.nml | xargs`")
     endif
   endif

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -336,6 +336,10 @@ program coupler_main
   use FMS
   use full_coupler_mod
 
+#ifdef CHEAT_MODE
+  use cheat_mode_mod, only: cheat_mode_invoke
+#endif
+
   implicit none
 
   !> model defined types.
@@ -687,13 +691,9 @@ program coupler_main
 
 !-----------------------------------------------------------------------
 
-#ifdef CHEAT_MODE_DIR
+#ifdef CHEAT_MODE
   if (fms_mpp_pe().eq.fms_mpp_root_pe()) then
-    if (cheatmode_on) then
-      call execute_command_line("tar -xf " // cheatmode_file // " --touch --overwrite")
-    else
-      call execute_command_line("tar -cf " // cheatmode_file // " `find . -type f -newer input.nml | xargs`")
-    endif
+    call cheat_mode_invoke
   endif
 #endif
 

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -1166,9 +1166,9 @@ contains
 
     if (cheatmode_on) then
       num_cpld_calls = 0
-      call fms_error_mesg("cheat mode", "Results tarball exists: Cheat mode is ON", NOTE)
+      call fms_error_mesg("cheat mode", "Results tarball will be extracted: " // cheatmode_file, NOTE)
     else
-      call fms_error_mesg("cheat mode", "Results tarball does not exist: Cheat mode is OFF", NOTE)
+      call fms_error_mesg("cheat mode", "Results tarball will be created: " // cheatmode_file, NOTE)
     endif
 #endif
 

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -1166,9 +1166,9 @@ contains
 
     if (cheatmode_on) then
       num_cpld_calls = 0
-      call error_mesg("cheat mode", "Results tarball exists: Cheat mode is ON", NOTE)
+      call fms_error_mesg("cheat mode", "Results tarball exists: Cheat mode is ON", NOTE)
     else
-      call error_mesg("cheat mode", "Results tarball does not exist: Cheat mode is OFF", NOTE)
+      call fms_error_mesg("cheat mode", "Results tarball does not exist: Cheat mode is OFF", NOTE)
     endif
 #endif
 

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -316,6 +316,11 @@ module full_coupler_mod
   !> coupled model initial date
   integer :: date_init(6) = (/ 0, 0, 0, 0, 0, 0 /)
 
+#ifdef CHEAT_MODE_DIR
+  logical, public :: cheatmode_on !> Whether to extract (true) or generate (false) a results tarball
+  character(:), allocatable, public :: cheatmode_file !> Filename of the results tarball
+#endif
+
 contains
 
 !#######################################################################
@@ -1149,6 +1154,22 @@ contains
       write(errunit,*) 'Exiting coupler_init at '&
                        //trim(walldate)//' '//trim(walltime)
     endif
+
+!-----------------------------------------------------------------------
+
+#ifdef CHEAT_MODE_DIR
+    allocate (character(len(CHEAT_MODE_DIR) + 26) :: cheatmode_file)
+    write (cheatmode_file, '(A,"/",I0.4,"-",I0.2,"-",I0.2,"_",I0.4,"-",I0.2,"-",I0.2,".tar")') &
+          CHEAT_MODE_DIR, date_init(1), date_init(2), date_init(3), date(1), date(2), date(3)
+    inquire (file=cheatmode_file, exist=cheatmode_on)
+
+    if (cheatmode_on) then
+      num_cpld_calls = 0
+      call error_mesg("cheat mode", "Results tarball exists: Cheat mode is ON", NOTE)
+    else
+      call error_mesg("cheat mode", "Results tarball does not exist: Cheat mode is OFF", NOTE)
+    endif
+#endif
 
   end subroutine coupler_init
 

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -1158,9 +1158,10 @@ contains
 !-----------------------------------------------------------------------
 
 #ifdef CHEAT_MODE_DIR
-    allocate (character(len(CHEAT_MODE_DIR) + 26) :: cheatmode_file)
+#define QUOTE(x) #x
+    allocate (character(len(QUOTE(CHEAT_MODE_DIR)) + 26) :: cheatmode_file)
     write (cheatmode_file, '(A,"/",I0.4,"-",I0.2,"-",I0.2,"_",I0.4,"-",I0.2,"-",I0.2,".tar")') &
-          CHEAT_MODE_DIR, date_init(1), date_init(2), date_init(3), date(1), date(2), date(3)
+          QUOTE(CHEAT_MODE_DIR), date_init(1), date_init(2), date_init(3), date(1), date(2), date(3)
     inquire (file=cheatmode_file, exist=cheatmode_on)
 
     if (cheatmode_on) then

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -1160,10 +1160,10 @@ contains
     call cheat_mode_init(date_init(1), date_init(2), date_init(3), date(1), date(2), date(3))
 
     if (cheat_mode_tarball_exists) then
-      call fms_error_mesg("cheat mode", "Results tarball will be extracted: " // cheat_mode_tarball_path, NOTE)
+      call fms_error_mesg("cheat mode", "Results tarball will be extracted: " // trim(cheat_mode_tarball_path), NOTE)
       num_cpld_calls = 0
     else
-      call fms_error_mesg("cheat mode", "Results tarball will be created: " // cheat_mode_tarball_path, NOTE)
+      call fms_error_mesg("cheat mode", "Results tarball will be created: " // trim(cheat_mode_tarball_path), NOTE)
     endif
 #endif
 

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -28,6 +28,10 @@ module full_coupler_mod
   use fms_io_mod,              only: fms_io_exit
 #endif
 
+#ifdef CHEAT_MODE
+  use cheat_mode_mod, only: cheat_mode_init, cheat_mode_tarball_exists, cheat_mode_tarball_path
+#endif
+
 ! model interfaces used to couple the component models:
 !               atmosphere, land, ice, and ocean
 !
@@ -315,11 +319,6 @@ module full_coupler_mod
 
   !> coupled model initial date
   integer :: date_init(6) = (/ 0, 0, 0, 0, 0, 0 /)
-
-#ifdef CHEAT_MODE_DIR
-  logical, public :: cheatmode_on !> Whether to extract (true) or generate (false) a results tarball
-  character(:), allocatable, public :: cheatmode_file !> Filename of the results tarball
-#endif
 
 contains
 
@@ -1157,18 +1156,14 @@ contains
 
 !-----------------------------------------------------------------------
 
-#ifdef CHEAT_MODE_DIR
-#define QUOTE(x) #x
-    allocate (character(len(QUOTE(CHEAT_MODE_DIR)) + 26) :: cheatmode_file)
-    write (cheatmode_file, '(A,"/",I0.4,"-",I0.2,"-",I0.2,"_",I0.4,"-",I0.2,"-",I0.2,".tar")') &
-          QUOTE(CHEAT_MODE_DIR), date_init(1), date_init(2), date_init(3), date(1), date(2), date(3)
-    inquire (file=cheatmode_file, exist=cheatmode_on)
+#ifdef CHEAT_MODE
+    call cheat_mode_init(date_init(1), date_init(2), date_init(3), date(1), date(2), date(3))
 
-    if (cheatmode_on) then
+    if (cheat_mode_tarball_exists) then
+      call fms_error_mesg("cheat mode", "Results tarball will be extracted: " // cheat_mode_tarball_path, NOTE)
       num_cpld_calls = 0
-      call fms_error_mesg("cheat mode", "Results tarball will be extracted: " // cheatmode_file, NOTE)
     else
-      call fms_error_mesg("cheat mode", "Results tarball will be created: " // cheatmode_file, NOTE)
+      call fms_error_mesg("cheat mode", "Results tarball will be created: " // cheat_mode_tarball_path, NOTE)
     endif
 #endif
 


### PR DESCRIPTION
Add "cheat mode", which can be enabled via the `CHEAT_MODE` CPP definition. When enabled, `coupler_init` will check for the existence of a tarball corresponding to the current segment in the directory specified by `dir` in `cheat_mode_nml`. If this tarball already exists, the main loop is skipped and the root PE extracts the tarball before the program exits (after `fms_end` is called). If the tarball does not exist, the main loop runs normally and the root PE creates the tarball before the program exits (after `fms_end` is called).

The purpose of this feature is to support the FRE workflow simulator. No runscript hacking is required with this approach, as the "cheat mode" model run behaves (from the runscript's perspective) exactly like an actual model run.