### PR TITLE
Add hooks to the full coupler

### DIFF
--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -360,8 +360,7 @@ program coupler_main
   type(FmsTime_type) :: Time_atmos, Time_ocean
   type(FmsTime_type) :: Time_flux_ice_to_ocean, Time_flux_ocean_to_ice
 
-  integer :: num_atmos_calls, na
-  integer :: num_cpld_calls, nc
+  integer :: nc, na
   integer :: current_timestep
 
   type(FmsNetcdfDomainFile_t), dimension(:), pointer :: Ice_bc_restart => NULL()
@@ -392,8 +391,8 @@ program coupler_main
     Ocean_ice_boundary, Ice_ocean_boundary, Land_ice_atmos_boundary, Land_ice_boundary,          &
     Ice_ocean_driver_CS, Ice_bc_restart, Ocn_bc_restart, ensemble_pelist, slow_ice_ocean_pelist, &
     conc_nthreads, coupler_clocks, coupler_components_obj, coupler_chksum_obj, &
-    Time_step_cpld, Time_step_atmos, Time_atmos, Time_ocean, num_cpld_calls,   &
-    num_atmos_calls, Time, Time_start, Time_end, Time_restart, Time_restart_current)
+    Time_step_cpld, Time_step_atmos, Time_atmos, Time_ocean, Time, Time_start, &
+    Time_end, Time_restart, Time_restart_current)
 
   if (do_chksum) call coupler_chksum_obj%get_coupler_chksums('coupler_init+', 0)
 
@@ -664,7 +663,7 @@ program coupler_main
         call coupler_intermediate_restart(Atm, Ice, Ocean, Ocean_state, Ocn_bc_restart, Ice_bc_restart, &
                                           Time, Time_restart, Time_restart_current, Time_start)
 
-    call coupler_summarize_timestep(nc, num_cpld_calls, coupler_chksum_obj, Atm%pe, omp_sec, imb_sec)
+    call coupler_summarize_timestep(nc, coupler_chksum_obj, Atm%pe, omp_sec, imb_sec)
 
     omp_sec(:)=0.
     imb_sec(:)=0.

--- a/full/coupler_main.F90
+++ b/full/coupler_main.F90
@@ -398,6 +398,11 @@ program coupler_main
 
   call fms_mpp_set_current_pelist()
   call fms_mpp_clock_end(coupler_clocks%initialization) !end initialization
+
+#ifdef COUPLER_MAIN_LOOP_PRE_HOOK
+  call COUPLER_MAIN_LOOP_PRE_HOOK
+#endif
+
   call fms_mpp_clock_begin(coupler_clocks%main)         !begin main loop
 
 !-----------------------------------------------------------------------
@@ -685,5 +690,9 @@ program coupler_main
   call fms_end
 
 !-----------------------------------------------------------------------
+
+#ifdef COUPLER_POST_HOOK
+  call COUPLER_POST_HOOK
+#endif
 
 end program coupler_main

--- a/full/full_coupler_mod.F90
+++ b/full/full_coupler_mod.F90
@@ -176,6 +176,9 @@ module full_coupler_mod
   integer, public :: ocean_nthreads=1 !< Number of OpenMP threads to use in the ocean
   integer, public :: radiation_nthreads=1 !< Number of threads to use for the radiation.
 
+  integer, public :: num_cpld_calls !< Number of iterations in the ocean/slow-ice loop
+  integer, public :: num_atmos_calls !< Number of iterations in the atmos/fast-land/fast-ice loop
+
   !> Indicates if this component should be executed.  If .FALSE., then execution is skipped.
   !! This is used when ALL the output fields sent by this component to the coupler have been
   !! overridden  using the data_override feature.  This is for advanced users only.
@@ -325,7 +328,7 @@ contains
       Ocean_ice_boundary, Ice_ocean_boundary, Land_ice_atmos_boundary, Land_ice_boundary,              &
       Ice_ocean_driver_CS, Ice_bc_restart, Ocn_bc_restart, ensemble_pelist, slow_ice_ocean_pelist, conc_nthreads, &
       coupler_clocks, coupler_components_obj, coupler_chksum_obj, Time_step_cpld, Time_step_atmos, Time_atmos, &
-      Time_ocean, num_cpld_calls, num_atmos_calls, Time, Time_start, Time_end, Time_restart, Time_restart_current)
+      Time_ocean, Time, Time_start, Time_end, Time_restart, Time_restart_current)
 
     implicit none
 
@@ -354,7 +357,6 @@ contains
     type(FMSTime_type), intent(inout) :: Time_step_cpld, Time_step_atmos, Time_atmos, Time_ocean
     type(FMSTime_type), intent(inout) :: Time, Time_start, Time_end, Time_restart, Time_restart_current
 
-    integer, intent(inout) :: num_cpld_calls, num_atmos_calls
 !
 !-----------------------------------------------------------------------
 !     local parameters
@@ -2390,12 +2392,10 @@ contains
 
   !> This subroutine mainly prints out the current timestep in the stdout.
   !! Chksum is computed if do_chksum = .True.
-  subroutine coupler_summarize_timestep(current_timestep, num_cpld_calls, coupler_chksum_obj, &
-                                        is_atmos_pe, omp_sec, imb_sec)
+  subroutine coupler_summarize_timestep(current_timestep, coupler_chksum_obj, is_atmos_pe, omp_sec, imb_sec)
 
     implicit none
     integer, intent(in) :: current_timestep  !< current_timestep, nc
-    integer, intent(in) :: num_cpld_calls    !< total number of outerloop timestep
     type(coupler_chksum_type), intent(in) :: coupler_chksum_obj  !< coupler_chksum_obj
     logical, intent(in)               :: is_atmos_pe             !< Atm%pe
     real, dimension(:), intent(inout) :: omp_sec, imb_sec        !< from omp computation


### PR DESCRIPTION
This PR adds macro-based hooks to the full coupler. The motivation for this change is to implement "cheat mode", in which the main loop would be skipped and a tarball would be extracted at the end of the program. The subroutines which implement the hooks would be stored in a separate repository.

This PR also moves some variables from the full coupler's main program into `full_coupler_mod`, so that they can be accessed by the cheat-mode hooks via `use`  rather than passing them as dummy arguments.