### PR TITLE
Clean up #ifndef _USE_LEGACY_LAND_ in atm_land_ice_flux_exchange_mod

### DIFF
--- a/full/atm_land_ice_flux_exchange.F90
+++ b/full/atm_land_ice_flux_exchange.F90
@@ -3086,7 +3086,11 @@ contains
     call FMS_XGRID_STOCK_MOVE_( &
          & TO   = fms_stock_constants_atm_stock(ISTOCK_WATER), &
          & FROM = fms_stock_constants_lnd_stock(ISTOCK_WATER), &
+#ifndef _USE_LEGACY_LAND_
          & stock_ug_data3d = data_lnd, &
+#else
+         & stock_data3d = data_lnd, &
+#endif
          & grid_index=X1_GRID_LND, &
          & xmap=xmap_sfc, &
          & delta_t=Dt_atm, &
@@ -3097,7 +3101,11 @@ contains
     call FMS_XGRID_STOCK_MOVE_( &
          & TO   = fms_stock_constants_atm_stock(ISTOCK_HEAT), &
          & FROM = fms_stock_constants_lnd_stock(ISTOCK_HEAT), &
+#ifndef _USE_LEGACY_LAND_
          & stock_ug_data3d = data_lnd * HLV, &
+#else
+         & stock_data3d = data_lnd * HLV, &
+#endif
          & grid_index=X1_GRID_LND, &
          & xmap=xmap_sfc, &
          & delta_t=Dt_atm, &

--- a/full/atm_land_ice_flux_exchange.F90
+++ b/full/atm_land_ice_flux_exchange.F90
@@ -20,6 +20,29 @@
 !> \file
 !> \brief Performs flux calculations and exchange grid operations for atmosphere, land and ice
 
+#undef FMS_DATA_OVERRIDE_
+#undef FMS_XGRID_PUT_TO_XGRID_
+#undef FMS_XGRID_STOCK_MOVE_ 
+#undef FMS_XGRID_SET_FRAC_AREA_ 
+#undef FMS_XGRID_GET_FROM_XGRID_ 
+#undef FMS_DIAG_REGISTER_FIELD_ 
+
+#ifndef _USE_LEGACY_LAND_
+#define FMS_DATA_OVERRIDE_ fms_data_override_ug
+#define FMS_XGRID_PUT_TO_XGRID_ fms_xgrid_put_to_xgrid_ug
+#define FMS_XGRID_STOCK_MOVE_ fms_xgrid_stock_move_ug
+#define FMS_XGRID_SET_FRAC_AREA_ fms_xgrid_set_frac_area_ug
+#define FMS_XGRID_GET_FROM_XGRID_ fms_xgrid_get_from_xgrid_ug
+#define FMS_DIAG_REGISTER_FIELD_ register_tiled_diag_field
+#else
+#define FMS_DATA_OVERRIDE_ fms_data_override
+#define FMS_XGRID_PUT_TO_XGRID_ fms_xgrid_put_to_xgrid
+#define FMS_XGRID_STOCK_MOVE_ fms_xgrid_stock_move
+#define FMS_XGRID_SET_FRAC_AREA_ fms_xgrid_set_frac_area
+#define FMS_XGRID_GET_FROM_XGRID_ fms_xgrid_get_from_xgrid
+#define FMS_DIAG_REGISTER_FIELD_ fms_diag_register_diag_field
+#endif
+  
 module atm_land_ice_flux_exchange_mod
 
 !! Components
@@ -89,21 +112,6 @@ use FMSconstants, only: rdgas, rvgas, cp_air, stefan, WTMAIR, HLV, HLF, Radius, 
             atm_stock_integrate,  &
             send_ice_mask_sic
 
-#ifndef _USE_LEGACY_LAND_
-#define FMS_DATA_OVERRIDE_ fms_data_override_ug
-#define FMS_XGRID_PUT_TO_XGRID_ fms_xgrid_put_to_xgrid_ug
-#define FMS_XGRID_STOCK_MOVE_ fms_xgrid_stock_move_ug
-#define FMS_XGRID_SET_FRAC_AREA_ fms_xgrid_set_frac_area_ug
-#define FMS_XGRID_GET_FROM_XGRID_ fms_xgrid_get_from_xgrid_ug
-#define FMS_DIAG_REGISTER_FIELD_ register_tiled_diag_field
-#else
-#define FMS_DATA_OVERRIDE_ fms_data_override
-#define FMS_XGRID_PUT_TO_XGRID_ fms_xgrid_put_to_xgrid
-#define FMS_XGRID_STOCK_MOVE_ fms_xgrid_stock_move
-#define FMS_XGRID_SET_FRAC_AREA_ fms_xgrid_set_frac_area
-#define FMS_XGRID_GET_FROM_XGRID_ fms_xgrid_get_from_xgrid
-#define FMS_DIAG_REGISTER_FIELD_ fms_diag_register_diag_field
-#endif
   
   !-----------------------------------------------------------------------
   character(len=128) :: version = '$Id$'
@@ -4092,3 +4100,10 @@ contains
 !#########################################################################
 
 end module atm_land_ice_flux_exchange_mod
+
+#undef FMS_DATA_OVERRIDE_
+#undef FMS_XGRID_PUT_TO_XGRID_
+#undef FMS_XGRID_STOCK_MOVE_ 
+#undef FMS_XGRID_SET_FRAC_AREA_ 
+#undef FMS_XGRID_GET_FROM_XGRID_ 
+#undef FMS_DIAG_REGISTER_FIELD_ 

--- a/full/atm_land_ice_flux_exchange.F90
+++ b/full/atm_land_ice_flux_exchange.F90
@@ -22,10 +22,10 @@
 
 #undef FMS_DATA_OVERRIDE_
 #undef FMS_XGRID_PUT_TO_XGRID_
-#undef FMS_XGRID_STOCK_MOVE_ 
-#undef FMS_XGRID_SET_FRAC_AREA_ 
-#undef FMS_XGRID_GET_FROM_XGRID_ 
-#undef FMS_DIAG_REGISTER_FIELD_ 
+#undef FMS_XGRID_STOCK_MOVE_
+#undef FMS_XGRID_SET_FRAC_AREA_
+#undef FMS_XGRID_GET_FROM_XGRID_
+#undef FMS_DIAG_REGISTER_FIELD_
 
 #ifndef _USE_LEGACY_LAND_
 #define FMS_DATA_OVERRIDE_ fms_data_override_ug
@@ -42,7 +42,7 @@
 #define FMS_XGRID_GET_FROM_XGRID_ fms_xgrid_get_from_xgrid
 #define FMS_DIAG_REGISTER_FIELD_ fms_diag_register_diag_field
 #endif
-  
+
 module atm_land_ice_flux_exchange_mod
 
 !! Components
@@ -112,7 +112,7 @@ use FMSconstants, only: rdgas, rvgas, cp_air, stefan, WTMAIR, HLV, HLF, Radius, 
             atm_stock_integrate,  &
             send_ice_mask_sic
 
-  
+
   !-----------------------------------------------------------------------
   character(len=128) :: version = '$Id$'
   character(len=128) :: tag = '$Name$'
@@ -1812,7 +1812,7 @@ contains
 
        if(id_tr_ref_land(tr) > 0) then
           call FMS_XGRID_GET_FROM_XGRID_ (diag_land, 'LND', ex_tr_ref(:,tr), xmap_sfc)
-#ifndef _USE_LEGACY_LAND_          
+#ifndef _USE_LEGACY_LAND_
           call send_tile_data (id_tr_ref_land(tr), diag_land)
 #else
           used = fms_diag_send_tile_averaged_data(id_tr_ref_land(tr), diag_land, &
@@ -1877,7 +1877,7 @@ contains
        where (ex_avail) ex_ref = ex_t_ca + (ex_t_atm-ex_t_ca) * ex_del_h
        if (id_t_ref_land > 0.or.id_tasLut_land > 0) then
           call FMS_XGRID_GET_FROM_XGRID_(diag_land, 'LND', ex_ref, xmap_sfc)
-#ifndef _USE_LEGACY_LAND_          
+#ifndef _USE_LEGACY_LAND_
           if (id_t_ref_land > 0)  call send_tile_data (id_t_ref_land, diag_land)
           if (id_tasLut_land > 0) call send_tile_data (id_tasLut_land, diag_land)
 #else
@@ -1907,7 +1907,7 @@ contains
             Land%tile_size, Time, mask = Land%mask )
 #endif
     endif
-   
+
     ! t_ref diagnostic at all atmos points
     call fms_xgrid_get_from_xgrid (diag_atm, 'ATM', ex_ref, xmap_sfc)
     if ( id_t_ref > 0 ) used = fms_diag_send_data ( id_t_ref, diag_atm, Time )
@@ -2935,7 +2935,7 @@ contains
        endwhere
        used = fms_diag_send_data ( id_tos, diag_atm, Time, rmask=frac_atm )
     endif
-    
+
     !------- new surface temperature only over land and sea-ice -----------
     if ( id_tslsi > 0 ) then
        ex_land_frac = 0.0
@@ -3112,7 +3112,7 @@ contains
     ! need this to avoid diag issues with tiling changes in update_land_slow
     call dump_tile_diag_fields(Time)
 #endif
-        
+
     call FMS_XGRID_GET_FROM_XGRID_(data_lnd, 'LND', ex_flux_tr(:,isphum), xmap_sfc)
 
     ! compute stock changes
@@ -3353,7 +3353,7 @@ contains
     elsewhere
        rmask = 0.0
     endwhere
-    
+
     call FMS_XGRID_PUT_TO_XGRID_(rmask, id, ex_mask, xmap)
 
   end subroutine put_logical_to_real_ug
@@ -3625,7 +3625,7 @@ contains
        id_tr_con_ref_land(:) = -1
        id_tr_ref_land(:)=  -1
 #endif
-       
+
        do tr = 1, n_exch_tr
           call fms_tracer_manager_get_tracer_names( MODEL_ATMOS, tr_table(tr)%atm, name, longname, units )
 
@@ -4103,7 +4103,7 @@ end module atm_land_ice_flux_exchange_mod
 
 #undef FMS_DATA_OVERRIDE_
 #undef FMS_XGRID_PUT_TO_XGRID_
-#undef FMS_XGRID_STOCK_MOVE_ 
-#undef FMS_XGRID_SET_FRAC_AREA_ 
-#undef FMS_XGRID_GET_FROM_XGRID_ 
-#undef FMS_DIAG_REGISTER_FIELD_ 
+#undef FMS_XGRID_STOCK_MOVE_
+#undef FMS_XGRID_SET_FRAC_AREA_
+#undef FMS_XGRID_GET_FROM_XGRID_
+#undef FMS_DIAG_REGISTER_FIELD_

--- a/full/atm_land_ice_flux_exchange.F90
+++ b/full/atm_land_ice_flux_exchange.F90
@@ -2413,9 +2413,6 @@ contains
        call FMS_XGRID_GET_FROM_XGRID_ (Land_boundary%z_bot, 'LND', ex_z_atm, xmap_sfc)
        call FMS_DATA_OVERRIDE_('LND', 'z_bot',  Land_boundary%z_bot, Time )
     endif
-    if (associated(Land_boundary%con_atm)) then
-       call FMS_XGRID_GET_FROM_XGRID_ (Land_boundary%con_atm, 'LND', ex_con_atm, xmap_sfc)
-    end if
 
     if (associated(Land_boundary%gex_atm2lnd)) then
        do n_gex=1,n_gex_atm2lnd
@@ -2423,6 +2420,12 @@ contains
           !add data_override here
        end do
     end if
+
+#ifndef _USE_LEGACY_LAND_
+    if (associated(Land_boundary%con_atm)) then
+       call FMS_XGRID_GET_FROM_XGRID_ (Land_boundary%con_atm, 'LND', ex_con_atm, xmap_sfc)
+    end if
+#endif
 
     Land_boundary%tr_flux = 0.0
     Land_boundary%dfdtr = 0.0
@@ -2746,7 +2749,7 @@ contains
     character(32) :: tr_name, tr_units ! tracer name
     integer :: n, i, m, ier
 
-    integer :: is, ie, OBl, l
+    integer :: is, ie, l
 
     !Balaji
     call fms_mpp_clock_begin(cplClock)
@@ -2924,7 +2927,6 @@ contains
        endwhere
        used = fms_diag_send_data ( id_tos, diag_atm, Time, rmask=frac_atm )
     endif
-#endif
     
     !------- new surface temperature only over land and sea-ice -----------
     if ( id_tslsi > 0 ) then
@@ -2946,7 +2948,7 @@ contains
        endwhere
        used = fms_diag_send_data ( id_tslsi, diag_atm, Time, rmask=frac_atm )
     endif
-
+#endif
 
     ! + slm, Mar 27 2002
     ! ------ new canopy temperature --------

--- a/t/null_model_build.sh
+++ b/t/null_model_build.sh
@@ -1,15 +1,17 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 #
 # Script to build a GFDL null model, using all null components, and run
 # a simple test on CI systems, like Travis CI or gitlab CI.
 
 # Determine the where this script lives, and set some variables that contain
 # other useful directories.
-script_root=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+script_root=$PWD
 
 # Create a new build directory, to keep from polluting the test
 # dirctory for a time when there are more tests.
-bld_dir=$(mktemp --directory $script_root/null.XXXXXX)
+bld_dir="$script_root/build"
+mkdir -p $bld_dir
+
 cd $bld_dir
 
 # Add a directory for the source(s)
@@ -33,7 +35,6 @@ fi
 
 # ocean_null
 git clone https://github.com/NOAA-GFDL/ocean_null.git $src_dir/ocean_null
-cd $bld_dir
 
 # atmos_null
 git clone https://github.com/NOAA-GFDL/atmos_null.git $src_dir/atmos_null
@@ -44,10 +45,10 @@ git clone https://github.com/NOAA-GFDL/land_null $src_dir/land_null
 # ice_null - need ice_param as well, and depends on ocean_null.
 git clone https://github.com/NOAA-GFDL/ice_param.git $src_dir/ice_param
 git clone https://github.com/NOAA-GFDL/ice_null.git $src_dir/ice_null
-cd $bld_dir
+
 
 # coupler - simply create symlink, this simplifies using the build system.
-ln -s $(readlink -f ../../) $src_dir/coupler
+ln -s `readlink -f ../../` $src_dir/coupler
 
 # Create the main Makefile
 sed -e 's/<TAB>/\t/' >$bld_dir/Makefile <<EOF
@@ -99,7 +100,7 @@ EOF
 mkdir -p $bld_dir/fms
 list_paths -o $bld_dir/fms/pathnames_fms $src_dir/FMS
 cd $bld_dir/fms
-mkmf -m Makefile -a $src_dir -b $bld_dir -p libfms.a -t $mkmf_template -g -c "-Duse_netCDF -Duse_libMPI -DMAXFIELDS_=200 -DMAXFIELDMETHODS_=200 -DINTERNAL_FILE_NML -DHAVE_GETTID" -o "-fallow-argument-mismatch" -IFMS/include -IFMS/mpp/include $bld_dir/fms/pathnames_fms
+mkmf -m Makefile -a $src_dir -b $bld_dir -p libfms.a -t $mkmf_template -g -c "-Duse_netCDF -Duse_libMPI -DMAXFIELDS_=200 -DMAXFIELDMETHODS_=200 -DINTERNAL_FILE_NML" -IFMS/include -IFMS/mpp/include $bld_dir/fms/pathnames_fms
 cd $bld_dir
 
 # libocean_null
@@ -141,7 +142,7 @@ cd $bld_dir
 mkdir -p $bld_dir/coupler_full
 list_paths -o $bld_dir/coupler_full/pathnames_coupler $src_dir/coupler/shared $src_dir/coupler/full
 cd $bld_dir/coupler_full
-mkmf -m Makefile -a $src_dir -b $bld_dir -p libcoupler_full.a -t $mkmf_template -g -c "-D_USE_LEGACY_LAND_ -Duse_AM3_physics -DINTERNAL_FILE_NML" -o "-I$bld_dir/land -I$bld_dir/ice -I$bld_dir/ice_param -I$bld_dir/atmos -I$bld_dir/ocean -I$bld_dir/fms" -IFMS/include $bld_dir/coupler_full/pathnames_coupler
+mkmf -m Makefile -a $src_dir -b $bld_dir -p libcoupler_full.a -t $mkmf_template -g -c "-D_USE_LEGACY_LAND_ -Duse_AM3_physics -DINTERNAL_FILE_NML" -o "-I$bld_dir/land -I$bld_dir/ice -I$bld_dir/ice_param -I$bld_dir/atmos -I$bld_dir/ocean -I$bld_dir/fms -fmax-errors=10" -IFMS/include $bld_dir/coupler_full/pathnames_coupler
 cd $bld_dir
 
 # libcoupler_simple
@@ -154,68 +155,3 @@ cd $bld_dir
 # Call make to build the executable with the full coupler
 make -j NETCDF=3 DEBUG=on coupler_full_test.x
 
-# Report on the status of the build
-if [ $? -eq 0 ]
-then
-  echo "::note title=Build Succeeded:: null model with full coupler built successfully."
-else
-  echo "::error title=Build Failed:: null model with full coupler failed compilation."
-  exit 1
-fi
-
-# Call make to build the executable with the full coupler
-make -j NETCDF=3 DEBUG=on coupler_simple_test.x
-
-# Report on the status of the build
-if [ $? -eq 0 ]
-then
-  echo "::note title=Build Succeeded:: null model with simple coupler built successfully."
-else
-  echo "::error title=Build Failed:: null model with simple coupler failed compilation."
-  exit 1
-fi
-# Run the null models test
-# Setup the run directory
-mkdir ${bld_dir}/run
-cd ${bld_dir}/run
-mkdir RESTART
-# Get the data files required for the run
-tarFile=coupler_null_test_data_full_simple.tar.gz
-curl -O ftp://ftp.gfdl.noaa.gov/perm/GFDL_pubrelease/test_data/${tarFile}
-tar zxf ${tarFile}
-
-# add an io layout to the full nml
-sed -i '22i  io_layout = 1, 1' input-full.nml
-
-# Get the full namelist
-ln -s input-full.nml input.nml
-# Run the null model with the full coupler
-mpiexec -n 1 ${bld_dir}/coupler_full_test.x
-
-# Report on the status of the run with the full coupler
-if [ $? -eq 0 ]
-then
-  echo "::note title=Run Succeeded - full coupler:: Full coupler null model ran successfully."
-else
-  echo "::error title=Run Failed - full coupler:: Full coupler null model run failed execution."
-  exit 1
-fi
-
-# Using the same run directory, setup for the simple coupler
-# Clear out the RESTART directory
-mv RESTART RESTART_full
-mkdir RESTART
-# Get the simple namelist
-rm input.nml
-ln -s input-simple.nml input.nml
-# Run the null simple coupler test
-mpiexec -n 1 ${bld_dir}/coupler_simple_test.x
-
-# Report on the status of the run with the simple coupler
-if [ $? -eq 0 ]
-then
-  echo "::note title=Run Succeeded - simple coupler:: simple coupler null model ran successfully"
-else
-  echo "::error title=Run Failed - simple coupler:: simple coupler null model run failed execution."
-  exit 1
-fi


### PR DESCRIPTION
Many lines of duplicate codes in  `atm_land_ice_flux_exchange_mod`, as shown below and linked [here](https://github.com/NOAA-GFDL/FMScoupler/blob/main/full/atm_land_ice_flux_exchange.F90#L974-L986),  are due to small differences in calls to FMS when the code is compiled with and without the `-D_USE_LEGACY_LAND_`  macro.   

```
#ifndef _USE_LEGACY_LAND_
    call fms_data_override_ug ('LND', 't_surf',     Land%t_surf,     Time)
    call fms_data_override_ug ('LND', 't_ca',       Land%t_ca,       Time)
    call fms_data_override_ug ('LND', 'rough_mom',  Land%rough_mom,  Time)
    call fms_data_override_ug ('LND', 'rough_heat', Land%rough_heat, Time)
    call fms_data_override_ug ('LND', 'albedo', Land%albedo,     Time)
#else
    call fms_data_override ('LND', 't_surf',     Land%t_surf,     Time)
    call fms_data_override ('LND', 't_ca',       Land%t_ca,       Time)
    call fms_data_override ('LND', 'rough_mom',  Land%rough_mom,  Time)
    call fms_data_override ('LND', 'rough_heat', Land%rough_heat, Time)
    call fms_data_override ('LND', 'albedo', Land%albedo,     Time)
#endif
```

This PR removes the repetitive code by introducing a new macro defined at the top of the modulefile to be the appropriate subroutine name based on the #ifdef state of \_USE_LEGACY_LAND\_:
```
#undef  FMS_DATA_OVERRIDE_
#ifndef _USE_LEGACY_LAND_
#define FMS_DATA_OVERRIDE_ fms_data_override_ug
#else
#define FMS_DATA_OVERRIDE_ fms_data_override
#endif
```
With the above definition, the example body of code changes to a much more understandable code that is easier to maintain:
```
call FMS_DATA_OVERRIDE_('LND', 't_surf',     Land%t_surf,     Time)
call FMS_DATA_OVERRIDE_('LND', 't_ca',       Land%t_ca,       Time)
call FMS_DATA_OVERRIDE_ ('LND', 'rough_mom',  Land%rough_mom,  Time)
call FMS_DATA_OVERRIDE_('LND', 'rough_heat', Land%rough_heat, Time)
call FMS_DATA_OVERRIDE_('LND', 'albedo', Land%albedo,     Time)
```

The code has been hand-checked by comparing the pre-processed files with the below commands:
1.  gfortran -E -D_USE_LEGACY_LAND_ -Duse_AM3_physics atm_land_ice_flux_exchange.F90
2. gfortran -E -Duse_AM3_physics atm_land_ice_flux_exchange.F90
3. gfortran -E -D_USE_LEGACY_LAND_ atm_land_ice_flux_exchange.F90